### PR TITLE
fix(security): prevent env var expansion in YAML body and defer API key resolution (#10, #12)

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -7,9 +7,22 @@ import type { AgentConfig } from "./types";
 
 // --- provider detection ---
 
+function resolve_api_key(raw_key: string): string {
+  const match = raw_key.match(/^\$(.+)$/);
+  if (match) {
+    const val = process.env[match[1]];
+    if (!val) {
+      throw new Error(`missing environment variable: ${raw_key}`);
+    }
+    return val;
+  }
+  // raw key pasted directly in config — use as-is
+  return raw_key;
+}
+
 function get_model(agent: AgentConfig) {
   const model_id = agent.model;
-  const api_key = agent.api_key;
+  const api_key = resolve_api_key(agent.api_key);
 
   if (model_id.startsWith("claude-") || model_id.startsWith("anthropic/")) {
     const provider = createAnthropic({ apiKey: api_key });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { load_config, expand_env_vars } from "./utils";
+import { load_config } from "./utils";
 import type { JoustConfig, AgentConfig, JoustDefaults } from "./types";
 
 // --- built-in defaults ---
@@ -46,7 +46,7 @@ function expand_agent_config(name: string, raw: Record<string, any>, defaults: J
   return {
     name,
     model: raw.model ?? "claude-sonnet-4-6",
-    api_key: expand_env_vars(raw.api_key ?? "$ANTHROPIC_API_KEY"),
+    api_key: raw.api_key ?? "$ANTHROPIC_API_KEY",
     system: raw.system ?? "",
     temperature: raw.temperature ?? defaults.temperature,
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,11 +48,8 @@ export function expand_env_vars(text: string): string {
 }
 
 export function load_config(path: string): unknown {
-  const raw = Bun.file(path);
-  // synchronous read
   const text = require("fs").readFileSync(path, "utf-8");
-  const expanded = expand_env_vars(text);
-  return parse_yaml(expanded);
+  return parse_yaml(text);
 }
 
 // --- history scanning ---

--- a/test/config_security.test.ts
+++ b/test/config_security.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { expand_env_vars, load_config } from "../src/utils";
+import { resolve_config } from "../src/config";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+describe("expand_env_vars", () => {
+  const origEnv = process.env.TEST_VAR;
+
+  beforeEach(() => {
+    process.env.TEST_VAR = "secret_value";
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) {
+      delete process.env.TEST_VAR;
+    } else {
+      process.env.TEST_VAR = origEnv;
+    }
+  });
+
+  test("resolves known env vars", () => {
+    expect(expand_env_vars("$TEST_VAR")).toBe("secret_value");
+  });
+
+  test("throws on missing env vars", () => {
+    expect(() => expand_env_vars("$NONEXISTENT_VAR_XYZ")).toThrow(
+      "missing environment variable: $NONEXISTENT_VAR_XYZ"
+    );
+  });
+
+  test("does not expand bare text without $", () => {
+    expect(expand_env_vars("just text")).toBe("just text");
+  });
+});
+
+describe("load_config (Issue #12 fix)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "joust-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("does NOT expand env vars in YAML body — $ in system prompt is preserved", () => {
+    const yamlContent = [
+      "defaults:",
+      "  temperature: 0.2",
+      "",
+      "agents:",
+      "  main:",
+      "    model: claude-sonnet-4-6",
+      "    api_key: $ANTHROPIC_API_KEY",
+      "    system: >",
+      "      This costs $500/month to run.",
+      "",
+    ].join("\n");
+
+    const configPath = join(tmpDir, "rfc.yaml");
+    writeFileSync(configPath, yamlContent);
+
+    // Should NOT throw "missing environment variable" for $500
+    const config = load_config(configPath) as any;
+    expect(config.agents.main.system).toContain("$500/month");
+    // api_key should still be raw $ENV_VAR reference
+    expect(config.agents.main.api_key).toBe("$ANTHROPIC_API_KEY");
+  });
+
+  test("preserves text like 'earned $1000 today' in system prompts", () => {
+    const yamlContent = [
+      "agents:",
+      "  main:",
+      "    model: claude-sonnet-4-6",
+      "    api_key: $ANTHROPIC_API_KEY",
+      "    system: I earned $1000 and spent $50 on $ITEM today",
+      "",
+    ].join("\n");
+
+    const configPath = join(tmpDir, "rfc.yaml");
+    writeFileSync(configPath, yamlContent);
+
+    const config = load_config(configPath) as any;
+    // All dollar amounts preserved as literal text
+    expect(config.agents.main.system).toBe("I earned $1000 and spent $50 on $ITEM today");
+  });
+});
+
+describe("resolve_config (Issue #10 fix)", () => {
+  let tmpDir: string;
+  const origKey = process.env.TEST_API_KEY;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "joust-test-"));
+    process.env.TEST_API_KEY = "sk-ant-real-secret-key-12345";
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (origKey === undefined) {
+      delete process.env.TEST_API_KEY;
+    } else {
+      process.env.TEST_API_KEY = origKey;
+    }
+  });
+
+  test("api_key is stored as raw $ENV_VAR, NOT resolved to plaintext", () => {
+    const yamlContent = [
+      "agents:",
+      "  main:",
+      "    model: claude-sonnet-4-6",
+      "    api_key: $TEST_API_KEY",
+      "    system: test",
+      "",
+    ].join("\n");
+
+    const configPath = join(tmpDir, "rfc.yaml");
+    mkdirSync(join(tmpDir, ".joust"), { recursive: true });
+    writeFileSync(configPath, yamlContent);
+
+    const config = resolve_config(tmpDir);
+    // api_key should be the raw reference, NOT the secret value
+    expect(config.agents["main"].api_key).toBe("$TEST_API_KEY");
+    // Should NOT contain the actual secret
+    expect(config.agents["main"].api_key).not.toContain("sk-ant-real-secret");
+  });
+
+  test("JSON.stringify(config) does NOT leak API keys", () => {
+    const yamlContent = [
+      "agents:",
+      "  main:",
+      "    model: claude-sonnet-4-6",
+      "    api_key: $TEST_API_KEY",
+      "    system: test",
+      "",
+    ].join("\n");
+
+    const configPath = join(tmpDir, "rfc.yaml");
+    writeFileSync(configPath, yamlContent);
+
+    const config = resolve_config(tmpDir);
+    const serialized = JSON.stringify(config);
+
+    // The actual secret must NOT appear in serialized config
+    expect(serialized).not.toContain("sk-ant-real-secret-key-12345");
+    // The raw reference should be there
+    expect(serialized).toContain("$TEST_API_KEY");
+  });
+
+  test("stack traces with config objects do NOT leak API keys", () => {
+    const yamlContent = [
+      "agents:",
+      "  main:",
+      "    model: claude-sonnet-4-6",
+      "    api_key: $TEST_API_KEY",
+      "    system: test",
+      "",
+    ].join("\n");
+
+    const configPath = join(tmpDir, "rfc.yaml");
+    writeFileSync(configPath, yamlContent);
+
+    const config = resolve_config(tmpDir);
+
+    // Simulate what happens when config appears in error messages
+    const errorDump = `Config: ${JSON.stringify(config)}`;
+    expect(errorDump).not.toContain("sk-ant-real-secret-key-12345");
+  });
+});


### PR DESCRIPTION
## Problem

Two related P0 security bugs in config/env handling:

**Issue #12**: `load_config()` runs `expand_env_vars()` on the entire YAML text before parsing. Any `$WORD` in a system prompt (e.g., `"costs $500/month"`) throws `missing environment variable` or silently substitutes an unintended value. Worse, if a system prompt contains `$ANTHROPIC_API_KEY` as example text, the actual key gets embedded in the parsed config.

**Issue #10**: `expand_agent_config()` resolves `$ANTHROPIC_API_KEY` into plaintext strings during config parsing. These resolved `AgentConfig` objects pass throughout the runtime. Any `JSON.stringify(config)` leaks the key into log files, stack traces, or network error messages.

## Root Cause

Two places call `expand_env_vars` too early:

1. `src/utils.ts:54` — `load_config()` expands the raw YAML text before parsing
2. `src/config.ts:49` — `expand_agent_config()` resolves `$ENV_VAR` at config construction time

## Fix (3 files, minimal changes)

1. **`src/utils.ts`**: `load_config()` now parses YAML directly without running `expand_env_vars`. The `expand_env_vars` function is kept for other potential uses.

2. **`src/config.ts`**: `expand_agent_config()` stores the raw `$ENV_VAR` reference string in `AgentConfig.api_key` instead of resolving it. Removed unused `expand_env_vars` import.

3. **`src/ai.ts`**: New `resolve_api_key()` function resolves `$ENV_VAR` lazily inside `get_model()`, right before constructing the provider client. This is the only place the actual key is needed.

## Security Impact

- **Before**: `JSON.stringify(config)` in debug logs, error messages, or stack traces exposes plaintext API keys
- **After**: `AgentConfig.api_key` always contains `"$ANTHROPIC_API_KEY"` (reference string), never the actual secret. The secret only exists transiently in `get_model()` scope.

## Tests

Added `test/config_security.test.ts` with regression tests:
- `expand_env_vars` correctly resolves and throws on missing vars
- `load_config` preserves `$500` in system prompts without expansion
- `resolve_config` stores raw `$ENV_VAR` in api_key field
- `JSON.stringify(config)` does NOT leak actual API keys
- Error dumps with config objects do NOT leak API keys

## Code Style

Follows project conventions: `snake_case` functions/variables, null-first, `parse_yaml` via `yaml` library, POSIX atomic write patterns preserved.