### PR TITLE
feat(config): configurable plateau parameters (phase 2.4 of #42)

### DIFF
--- a/spool/gh/issue/49-configurable-plateau/README.md
+++ b/spool/gh/issue/49-configurable-plateau/README.md
@@ -1,0 +1,36 @@
+# #49 — configurable plateau parameters
+
+**Spec:** https://github.com/ahoward/joust/issues/49
+**Status:** ready-for-review
+**Branch:** `phase-2.4-configurable-plateau`
+
+## Plan
+
+Single-commit change. Tests + small migration of constants → config.
+
+1. `src/types.ts`: add `plateau_epsilon` and `plateau_k` to `JoustDefaults`.
+2. `src/config.ts`: include them in `generate_default_config` output.
+3. `src/run.ts`: read from config, drop the `PLATEAU_EPSILON` / `PLATEAU_K` constants. Pass them into `is_plateau`.
+4. `test/run.test.ts`: pass values into `is_plateau` (function signature changes).
+5. Run `./dev/test`, `bun build`, smoke test.
+
+## Done
+
+- types.ts: `JoustDefaults` gains `plateau_epsilon` and `plateau_k` (both optional with `?`).
+- config.ts: `DEFAULT_DEFAULTS` includes them; `generate_default_config` emits them in the JSON.
+- run.ts: read into `plateau_epsilon` / `plateau_k` locals at run start; threaded through `is_plateau(history, epsilon, k)`. Constants renamed to `DEFAULT_*` and used as fallback.
+- test/run.test.ts: existing cases pass `E, K` literals. 3 new cases for custom epsilon/k.
+- 145 tests pass (was 142). Binary compiles.
+
+## Next
+
+Nothing — ready to merge after review + dogfood smoke.
+
+## Pitfalls
+
+- Existing snowballs / configs do not have these fields. `resolve_config` should default-fill so we don't break older runs.
+- `is_plateau` currently takes only `history: number[]`. Signature changes to `is_plateau(history, epsilon, k)`. Callers must thread through.
+
+## Open questions
+
+- None.

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,8 @@ const DEFAULT_DEFAULTS: JoustDefaults = {
   max_retries: 3,
   compaction_threshold: 10,
   max_rounds: 1,
+  plateau_epsilon: 0.02,
+  plateau_k: 2,
 };
 
 // default panel: two peer lead architects. same system prompt, different
@@ -364,6 +366,8 @@ export function generate_default_config(preset: Preset = "mixed"): string {
       max_retries: 3,
       compaction_threshold: 10,
       max_rounds: 1,
+      plateau_epsilon: 0.02,         // strategy-scoring: end-of-loop slack
+      plateau_k: 2,                  // strategy-scoring: rounds-flat threshold
       // workspace: ".",             // default: project dir. set to override
       // max_tool_steps: 10,         // cap tool-use round-trips per agent turn
     },

--- a/src/run.ts
+++ b/src/run.ts
@@ -61,17 +61,19 @@ function cleanup_tmp_files(dir: string): void {
 
 // --- strategy scoring helpers (phase 1 of #42) ---
 
-const PLATEAU_EPSILON = 0.02;
-const PLATEAU_K = 2;
+// fallback values when config doesn't supply them. real values come from
+// JoustDefaults.plateau_epsilon / plateau_k, plumbed in from resolve_config.
+const DEFAULT_PLATEAU_EPSILON = 0.02;
+const DEFAULT_PLATEAU_K = 2;
 
-// a plateau is K+1 consecutive aggregates with no improvement > epsilon.
+// a plateau is k+1 consecutive aggregates with no improvement > epsilon.
 // cheap to detect, no LLM calls.
-function is_plateau(history: number[]): boolean {
-  if (history.length < PLATEAU_K + 1) return false;
-  const recent = history.slice(-PLATEAU_K - 1);
+function is_plateau(history: number[], epsilon: number, k: number): boolean {
+  if (history.length < k + 1) return false;
+  const recent = history.slice(-k - 1);
   const peak = recent[0]!;
   for (let i = 1; i < recent.length; i++) {
-    if (recent[i]! - peak > PLATEAU_EPSILON) return false;
+    if (recent[i]! - peak > epsilon) return false;
   }
   return true;
 }
@@ -249,6 +251,8 @@ export async function run(dir: string, options: RunOptions = {}): Promise<void> 
   let jousters = get_jousters(config);
   const max_retries = config.defaults.max_retries;
   const max_rounds = config.defaults.max_rounds;
+  const plateau_epsilon = config.defaults.plateau_epsilon ?? DEFAULT_PLATEAU_EPSILON;
+  const plateau_k = config.defaults.plateau_k ?? DEFAULT_PLATEAU_K;
   const interactive_interval = options.interactive ?? 0;
   let workspace_tools: ToolSet | undefined;
   let max_tool_steps: number | undefined;
@@ -786,9 +790,9 @@ export async function run(dir: string, options: RunOptions = {}): Promise<void> 
         snowball.best_scoring.weighted_aggregate,
       ];
       snowball = { ...snowball, aggregate_history: hist };
-      if (is_plateau(hist)) {
+      if (is_plateau(hist, plateau_epsilon, plateau_k)) {
         plateaued = true;
-        log(`\nplateau detected (${PLATEAU_K} rounds without improvement of > ${PLATEAU_EPSILON}), ending run`);
+        log(`\nplateau detected (${plateau_k} rounds without improvement of > ${plateau_epsilon}), ending run`);
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,11 @@ export interface JoustDefaults {
   max_rounds: number;
   workspace?: string;
   max_tool_steps?: number;
+  // strategy-scoring plateau detection (#49). loop ends when the
+  // best_aggregate hasn't improved by > plateau_epsilon across the
+  // last (plateau_k + 1) rounds.
+  plateau_epsilon?: number;
+  plateau_k?: number;
 }
 
 export interface JoustConfig {

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -2,33 +2,53 @@ import { describe, test, expect } from "bun:test";
 import { _is_plateau, _migrate_snowball } from "../src/run.ts";
 import type { Snowball } from "../src/types.ts";
 
+// default values matching the prior hardcoded constants. now configurable
+// via JoustDefaults.plateau_epsilon / plateau_k (#49); these tests use the
+// historical defaults to preserve existing coverage. additional cases below
+// exercise non-default ε/k.
+const E = 0.02;
+const K = 2;
+
 describe("is_plateau", () => {
   test("too few points to decide", () => {
-    expect(_is_plateau([])).toBe(false);
-    expect(_is_plateau([0.5])).toBe(false);
-    expect(_is_plateau([0.5, 0.6])).toBe(false);
+    expect(_is_plateau([], E, K)).toBe(false);
+    expect(_is_plateau([0.5], E, K)).toBe(false);
+    expect(_is_plateau([0.5, 0.6], E, K)).toBe(false);
   });
 
   test("flat 3 = plateau (K=2)", () => {
-    expect(_is_plateau([0.5, 0.5, 0.5])).toBe(true);
+    expect(_is_plateau([0.5, 0.5, 0.5], E, K)).toBe(true);
   });
 
   test("still improving > epsilon breaks plateau", () => {
-    expect(_is_plateau([0.5, 0.6, 0.7])).toBe(false);
+    expect(_is_plateau([0.5, 0.6, 0.7], E, K)).toBe(false);
   });
 
   test("tiny improvement within epsilon counts as plateau", () => {
     // epsilon is 0.02 — a move of 0.01 across the window is plateau
-    expect(_is_plateau([0.8, 0.81, 0.81])).toBe(true);
+    expect(_is_plateau([0.8, 0.81, 0.81], E, K)).toBe(true);
   });
 
   test("regression counts as plateau (no improvement)", () => {
-    expect(_is_plateau([0.8, 0.7, 0.6])).toBe(true);
+    expect(_is_plateau([0.8, 0.7, 0.6], E, K)).toBe(true);
   });
 
   test("looks at the TAIL K+1, not the whole history", () => {
     // earlier improvement doesn't save a flat tail
-    expect(_is_plateau([0.1, 0.5, 0.9, 0.9, 0.9])).toBe(true);
+    expect(_is_plateau([0.1, 0.5, 0.9, 0.9, 0.9], E, K)).toBe(true);
+  });
+
+  test("custom epsilon: improvement of 0.05 is plateau when ε=0.1", () => {
+    expect(_is_plateau([0.6, 0.65, 0.65], 0.1, 2)).toBe(true);
+  });
+
+  test("custom epsilon: improvement of 0.05 breaks plateau when ε=0.01", () => {
+    expect(_is_plateau([0.6, 0.65, 0.65], 0.01, 2)).toBe(false);
+  });
+
+  test("custom k=3: needs 4 flat points", () => {
+    expect(_is_plateau([0.5, 0.5, 0.5], E, 3)).toBe(false);
+    expect(_is_plateau([0.5, 0.5, 0.5, 0.5], E, 3)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Implements #49. Moves `PLATEAU_EPSILON` and `PLATEAU_K` from constants in `src/run.ts` to optional fields on `JoustDefaults`. Defaults stay 0.02 and 2 — no behavior change. Operators can now tune via `config.json`.

`is_plateau(history, epsilon, k)` signature change is internal-only; tests updated.

145 tests pass. Binary compiles.

Refs: #42, #49