### PR TITLE
feat(visibility): polish-regression + strategy-declination logs (phase 2.3 of #42)

### DIFF
--- a/spool/gh/issue/50-visibility/README.md
+++ b/spool/gh/issue/50-visibility/README.md
@@ -1,0 +1,35 @@
+# #50 — visibility (polish-regression, strategy-declination, carryover-summon)
+
+**Spec:** https://github.com/ahoward/joust/issues/50
+**Status:** ready-for-review
+**Branch:** `phase-2.3-visibility`
+
+## Plan
+
+Three logging additions. Independent from each other but ship together.
+
+1. **Polish-regression log.** When `polish_is_best === false` after scoring, log per-strategy aggregate delta + color tier change + top-2 dim regressions. Today's `polish complete (... kept previous best)` line is too quiet.
+2. **Strategy-declination log + snowball field.** When a strategy's `bootstrap()` returns null, capture the LLM's rationale (when available) and log it at init. Also surface in `joust /status`. Snowball gets `declined_strategies?: { name, rationale }[]`.
+3. **Carryover-summon log point.** Just the log point — the actual carryover mechanism lands with #52. Adds a no-op log helper that #52 will wire up.
+
+## Done
+
+- `log_polish_regression(prev, curr)` in src/run.ts — emits a multi-line block when polish regresses. Per-strategy aggregate delta, color-tier change, top-2 dim drops with rationale.
+- `log_summon_carryover(round, snowball)` placeholder for #52 — reads `snowball.pending_summon` and emits a one-liner. Not yet wired to a call site (waits for #52 to set the field).
+- Snowball gains `declined_strategies?: { name, rationale }[]`.
+- `bootstrap_strategies` return type changes to `{ config, declined }`. Both decline (null returned) and error (exception) populate `declined`. Per-name `[name] declined — <reason>` logged at init time.
+- `joust /status` adds a `declined:` panel listing each declined strategy + rationale.
+- test/init.test.ts updated for new return shape; 3 cases assert decline tracking covers null + error + non-decline.
+
+## Next
+
+Nothing — ready to merge after dogfood smoke.
+
+## Pitfalls
+
+- Strategy `bootstrap()` doesn't currently return a rationale even when it declines. Need to extend the return type from `T | null` to `{ config: T } | { declined: string }`. Or augment with a side-channel. Either way, every strategy file changes — bigger surface than I want here. Alternative: leave bootstraps as-is, just capture absence and label it "(no rationale captured)" until phase 2 surfaces a richer interface. **Going with this.**
+- Top-2 dim regressions — pick by largest score drop (max → min sort by `prev.score - curr.score`).
+
+## Open questions
+
+- Should polish-regression also write a marker file (like `.needs-attention`)? My read: no — this is a soft signal. Polish regression is normal; it shouldn't trigger operator interrupt.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,6 +50,15 @@ export function status(dir: string): void {
       log(`  color:      ${strategies.color.question}`);
     }
   }
+  // declined strategies — captured at init, surfaced here so operators
+  // can see WHICH strategies opted out and why (#50).
+  const declined = snowball.declined_strategies ?? [];
+  if (declined.length > 0) {
+    log(`declined:   ${declined.map((d) => d.name).join(", ")}`);
+    for (const d of declined) {
+      log(`  ${d.name}: ${d.rationale.slice(0, 200)}`);
+    }
+  }
   const best = snowball.best_scoring;
   if (best) {
     log(`best:       aggregate=${best.weighted_aggregate.toFixed(3)}${best.color_tier ? ` tier=${best.color_tier}` : ""}`);

--- a/src/init.ts
+++ b/src/init.ts
@@ -35,6 +35,11 @@ import {
 // runs each registered strategy's bootstrap() against the prompt. a
 // strategy that returns null is omitted from the final config. errors
 // in one strategy don't kill the others (per-strategy try/catch).
+// returns the bootstrapped strategies config + a list of strategies that
+// declined to apply (with the best rationale we can capture). #50 wired
+// the declined list into snowball.declined_strategies so /status surfaces
+// it. strategies don't currently return a structured rationale on decline,
+// so the rationale is a placeholder until a richer interface lands.
 async function bootstrap_strategies(
   main: AgentConfig,
   prompt: string,
@@ -44,12 +49,16 @@ async function bootstrap_strategies(
     log_dir?: string;
     signal?: AbortSignal;
   }
-): Promise<StrategiesConfig> {
+): Promise<{
+  config: StrategiesConfig;
+  declined: { name: string; rationale: string }[];
+}> {
   const names = list_strategies();
   log_status("main", `bootstrapping strategies: ${names.join(", ")}`);
 
-  const pairs = await Promise.all(
-    names.map(async (name) => {
+  type Result = readonly [string, unknown, "applied" | "declined" | "errored", string];
+  const pairs: Result[] = await Promise.all(
+    names.map(async (name): Promise<Result> => {
       const s = get_strategy(name as StrategyName);
       try {
         const cfg = await s.bootstrap({
@@ -60,22 +69,29 @@ async function bootstrap_strategies(
           log_dir: options?.log_dir,
           signal: options?.signal,
         });
-        return [name, cfg] as const;
+        if (cfg) return [name, cfg, "applied", ""] as const;
+        return [name, null, "declined", "classifier returned null (strategy judged not applicable)"] as const;
       } catch (err: any) {
         log_status(name, `bootstrap error: ${err.message}`);
-        return [name, null] as const;
+        return [name, null, "errored", `bootstrap error: ${err.message}`] as const;
       }
     })
   );
 
   const out: StrategiesConfig = {};
-  for (const [name, cfg] of pairs) {
-    if (!cfg) continue;
-    if (name === "invariants") out.invariants = cfg as any;
-    else if (name === "rubric") out.rubric = cfg as any;
-    else if (name === "color") out.color = cfg as any;
+  const declined: { name: string; rationale: string }[] = [];
+  for (const [name, cfg, status, rationale] of pairs) {
+    if (status === "applied" && cfg) {
+      if (name === "invariants") out.invariants = cfg as any;
+      else if (name === "rubric") out.rubric = cfg as any;
+      else if (name === "color") out.color = cfg as any;
+    } else {
+      // both declined and errored go into the declined list with their rationale
+      declined.push({ name, rationale });
+      log_status(name, `declined — ${rationale}`);
+    }
   }
-  return out;
+  return { config: out, declined };
 }
 
 // --- read prompt from $EDITOR ---
@@ -178,7 +194,7 @@ export async function init(args: string[], preset?: Preset): Promise<string> {
 
   // strategy bootstrap (phase 1 of #42) — ask each registered strategy
   // whether it applies to this prompt and collect the config blocks.
-  const strategies = await bootstrap_strategies(main, prompt, {
+  const { config: strategies, declined } = await bootstrap_strategies(main, prompt, {
     tools: workspace_tools,
     max_tool_steps,
     log_dir: join(dir, "logs"),
@@ -197,6 +213,7 @@ export async function init(args: string[], preset?: Preset): Promise<string> {
     strategies,
     best_draft: result.draft,
     aggregate_history: [],
+    declined_strategies: declined.length > 0 ? declined : undefined,
   };
 
   // write config snapshot — auto-detect preset from env if not specified

--- a/src/run.ts
+++ b/src/run.ts
@@ -135,6 +135,76 @@ async function score_candidate(
   }
 }
 
+// --- visibility helpers (#50) ---
+//
+// when polish scores below current best, emit a multi-line log block that
+// shows the per-strategy aggregate delta, color-tier change if any, and
+// the top-2 dim regressions. operator can see *why* the polish was
+// dropped without spelunking through history.
+function log_polish_regression(
+  prev: ScoringResult,
+  curr: ScoringResult
+): void {
+  const lines: string[] = [];
+  lines.push(
+    `[main] polish regressed: agg ${prev.weighted_aggregate.toFixed(3)} → ${curr.weighted_aggregate.toFixed(3)} (kept previous best)`
+  );
+
+  if (prev.color_tier !== curr.color_tier) {
+    lines.push(`  color: ${prev.color_tier ?? "(none)"} → ${curr.color_tier ?? "(none)"}`);
+  }
+
+  // per-strategy aggregate delta
+  const prev_by_name = new Map(prev.scorecards.map((c) => [c.strategy, c]));
+  for (const cur of curr.scorecards) {
+    const p = prev_by_name.get(cur.strategy);
+    if (!p) continue;
+    if (Math.abs(cur.aggregate - p.aggregate) < 0.001) continue;
+    lines.push(
+      `  ${cur.strategy}: ${p.aggregate.toFixed(3)} → ${cur.aggregate.toFixed(3)}`
+    );
+  }
+
+  // top-2 individual dim regressions across all strategies
+  type Drop = { strategy: string; dim: string; before: number; after: number; rationale: string };
+  const drops: Drop[] = [];
+  for (const cur of curr.scorecards) {
+    const p = prev_by_name.get(cur.strategy);
+    if (!p) continue;
+    const p_dims = new Map(p.dimensions.map((d) => [d.name, d]));
+    for (const d of cur.dimensions) {
+      const pd = p_dims.get(d.name);
+      if (!pd) continue;
+      if (d.score < pd.score) {
+        drops.push({
+          strategy: cur.strategy,
+          dim: d.name,
+          before: pd.score,
+          after: d.score,
+          rationale: d.rationale,
+        });
+      }
+    }
+  }
+  drops.sort((a, b) => b.before - b.after - (a.before - a.after));
+  for (const d of drops.slice(0, 2)) {
+    lines.push(`  - ${d.strategy}/${d.dim}: ${d.before} → ${d.after} (${d.rationale.slice(0, 100)})`);
+  }
+
+  for (const l of lines) log(l);
+}
+
+// summon carryover log point — placeholder for #52. wired now so the
+// downstream issue can fill in real state without a second touchup of
+// this code path.
+function log_summon_carryover(round: number, snowball: Snowball): void {
+  const pending = (snowball as any).pending_summon;
+  if (!pending) return;
+  log(
+    `[round ${round}] carrying over: ${pending.specialist} specialist asked "${(pending.ask ?? "").slice(0, 80)}", prior attempt rejected for: ${(pending.last_rejection ?? "(no rejection captured)").slice(0, 100)}`
+  );
+}
+
 // --- options ---
 
 export interface RunOptions {
@@ -769,6 +839,9 @@ export async function run(dir: string, options: RunOptions = {}): Promise<void> 
           const score_label = `agg=${polish_scoring.weighted_aggregate.toFixed(3)}${polish_scoring.color_tier ? ` tier=${polish_scoring.color_tier}` : ""}`;
           if (polish_is_best) {
             log_status("main", `polish complete (${score_label}, new best)`);
+          } else if (snowball.best_scoring) {
+            // emit a richer regression block instead of the bare one-liner
+            log_polish_regression(snowball.best_scoring, polish_scoring);
           } else {
             log_status("main", `polish complete (${score_label}, kept previous best)`);
           }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,9 @@ export interface Snowball {
   best_draft?: string;
   best_scoring?: ScoringResult;
   aggregate_history?: number[];  // for plateau detection across rounds
+  // strategies that bootstrap() declined to apply (#50). captured at init
+  // so /status can show the operator which strategies opted out and why.
+  declined_strategies?: { name: string; rationale: string }[];
 }
 
 // --- history ---

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -32,17 +32,21 @@ function install_double<N extends "rubric" | "invariants" | "color">(
 }
 
 describe("bootstrap_strategies", () => {
-  test("returns {} when every strategy declines", async () => {
+  test("returns empty config + 3 declined when every strategy declines", async () => {
     _reset_strategies();
     install_double("invariants", null);
     install_double("rubric", null);
     install_double("color", null);
 
     const out = await _bootstrap_strategies(fake_agent, "a prompt");
-    expect(out).toEqual({});
+    expect(out.config).toEqual({});
+    expect(out.declined).toHaveLength(3);
+    for (const d of out.declined) {
+      expect(d.rationale).toContain("classifier returned null");
+    }
   });
 
-  test("returns only strategies that returned non-null", async () => {
+  test("returns only strategies that returned non-null; declined are tracked", async () => {
     _reset_strategies();
     install_double("invariants", {
       MUST: ["a"],
@@ -55,12 +59,13 @@ describe("bootstrap_strategies", () => {
     });
 
     const out = await _bootstrap_strategies(fake_agent, "spec + safety check");
-    expect(out.invariants).toEqual({ MUST: ["a"], SHOULD: [], MUST_NOT: [] });
-    expect(out.rubric).toBeUndefined();
-    expect(out.color).toEqual({ question: "is this safe?" });
+    expect(out.config.invariants).toEqual({ MUST: ["a"], SHOULD: [], MUST_NOT: [] });
+    expect(out.config.rubric).toBeUndefined();
+    expect(out.config.color).toEqual({ question: "is this safe?" });
+    expect(out.declined.map((d) => d.name)).toEqual(["rubric"]);
   });
 
-  test("errors in one strategy's bootstrap don't take down the others", async () => {
+  test("errors in one strategy's bootstrap surface as declined with the error message", async () => {
     _reset_strategies();
     register_strategy({
       name: "invariants",
@@ -73,7 +78,9 @@ describe("bootstrap_strategies", () => {
     install_double("color", null);
 
     const out = await _bootstrap_strategies(fake_agent, "prompt");
-    expect(out.invariants).toBeUndefined();
-    expect(out.rubric?.dimensions).toHaveLength(1);
+    expect(out.config.invariants).toBeUndefined();
+    expect(out.config.rubric?.dimensions).toHaveLength(1);
+    const inv = out.declined.find((d) => d.name === "invariants");
+    expect(inv?.rationale).toContain("simulated");
   });
 });


### PR DESCRIPTION
Implements #50.

- `log_polish_regression()` replaces the quiet `polish complete (kept previous best)` line with a multi-line block: per-strategy aggregate delta, color-tier change, top-2 dim regressions with rationale.
- `bootstrap_strategies` returns `{ config, declined }`. Both null-returns and bootstrap errors land in `declined`. Logged at init time and surfaced in `joust /status`.
- Snowball gains `declined_strategies?: { name, rationale }[]`.
- `log_summon_carryover()` placeholder added — #52 wires it up.

145 tests pass. Binary compiles. Refs: #42, #50.