### PR TITLE
feat(scoring): cheap-model scorer override (phase 2.1 of #42)

### DIFF
--- a/spool/gh/issue/51-cheap-scorer/README.md
+++ b/spool/gh/issue/51-cheap-scorer/README.md
@@ -1,0 +1,43 @@
+# #51 — cheap-model scorer override
+
+**Spec:** https://github.com/ahoward/joust/issues/51
+**Status:** ready-for-review
+**Branch:** `phase-2.1-cheap-scorer`
+
+## Plan
+
+1. `JoustDefaults` gains optional `scorer_model: string`.
+2. `generate_default_config` emits it commented-out.
+3. New helper `build_scorer_agent(main, scorer_model)` in src/config.ts — clones main with `model` overridden. Returns main as-is when scorer_model is unset.
+4. In `src/run.ts`, build the scorer agent once per round (config can reload), pass it into `score_candidate` as a separate arg.
+5. `score_candidate` threads scorer agent into `score_draft(scorer, ...)` — note that `score_draft` already takes `main: AgentConfig`, just give it the cheaper agent.
+6. Bootstrap stays on real main (separate code path in init.ts).
+7. `joust /plan` mentions scorer model in output.
+8. Tests: scorer_model defaults to main when null; non-null applies; build_scorer_agent unit tests.
+
+## Done
+
+- types.ts: `JoustDefaults` gains optional `scorer_model`.
+- config.ts: emits `scorer_model` commented-out in `generate_default_config`. New `build_scorer_agent(main, scorer_model?)` clones main with model swapped (api_key, system, temperature inherit). Returns main as-is when scorer_model is unset or matches main.
+- run.ts: `scorer = build_scorer_agent(main, config.defaults.scorer_model)` once per round (so config edits between rounds take effect). Passed to `score_candidate(scorer, ...)` for both jouster and polish gates. Bootstrap stays on real main (separate code path in init.ts).
+- score_candidate's first arg renamed `main → scorer` for clarity.
+- commands.ts /plan: when scorer_model differs, plan output shows it on its own line with a "noisier; unset for final run" note. Cost breakdown splits main (lint+polish) from scorer (strategy scoring) so two-model setups show their share.
+- 3 new tests (test/config.test.ts) for build_scorer_agent: unset returns main, equal-model returns main, different-model returns clone with model swapped and main unmutated.
+- 148 tests pass, binary compiles.
+
+## Next
+
+Nothing — ready to merge after dogfood smoke.
+
+## Pitfalls
+
+- If user sets `scorer_model: "claude-haiku-4-5"` but their config doesn't define an agent that uses haiku's API key, we need to handle the API key resolution. **Decision:** scorer_model uses main's API key. The model string is the only override. Document this in the README. Multi-provider scorers (e.g., main=Claude, scorer=Gemini) are a phase-3 concern.
+
+## Open questions
+
+- Should scorer_model also override `temperature`? Probably no — temp=0 is desired for scorers regardless.
+
+## Deferred to follow-on issues
+
+- **Floor-violation pre-check.** I'd planned to implement deterministic substring matching for MUST_NOT before paying for an LLM call. But: most rules are semantic ("MUST be atomic", "MUST NOT introduce new deps"), not literal. Per-rule discipline is needed. Tracking as a future issue if the noise turns out to be a real problem.
+- **Tiebreaker re-run with main agent on N consecutive cheap-scorer rejections.** Lower priority; ship cheap scorer and observe.

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -201,10 +201,20 @@ export function plan(dir: string): void {
   const total_input_tokens = total_calls * tokens_per_call;
   const total_output_tokens = Math.ceil(total_input_tokens * 0.5);
 
+  // when scorer_model is configured, scoring calls go to the cheaper model;
+  // bootstrap + lint + polish stay on main. count them separately.
+  const scorer_model_id = config.defaults.scorer_model;
+  const scorer_overridden = !!scorer_model_id && scorer_model_id !== main.model;
+  const scorer_label = scorer_overridden ? scorer_model_id! : main.model;
+
   log(`=== joust plan ===`);
   log(`agents: main (${main.model}) + ${jousters.length} jousters`);
   for (const j of jousters) {
     log(`  - ${j.name} (${j.model})`);
+  }
+  if (scorer_overridden) {
+    log(`scorer: ${scorer_label} (cheap-scorer override; bootstrap stays on ${main.model})`);
+    log(`  note: cheaper scoring is also noisier — unset scorer_model for the final pre-publication run.`);
   }
   log(`strategies: ${strategy_count} (${Object.keys(latest?.snowball.strategies ?? {}).join(", ") || "(legacy/none)"})`);
   log(`rounds: ${max_rounds} | retries: ${max_retries}/agent`);
@@ -213,15 +223,32 @@ export function plan(dir: string): void {
   log(`tokens: ~${Math.round(total_input_tokens / 1000)}K input, ~${Math.round(total_output_tokens / 1000)}K output`);
   log(``);
 
-  // cost breakdown by model — main does lint + scoring passes + polish
+  // cost breakdown by model. main does lint + polish; scorer (= main when
+  // scorer_model unset) handles strategy scoring calls.
   const model_usage: Record<string, { input: number; output: number }> = {};
-  const main_calls =
-    (jousters.length * (1 + strategy_count) + 1 + strategy_count) * max_rounds;
+  // main: 1 lint per jouster mutation + 1 lint per polish + 1 polish call = (jousters + 2) per round
+  const main_lint_polish_calls = (jousters.length + 2) * max_rounds;
+  // scorer: strategy_count score calls per jouster + strategy_count per polish
+  const scorer_calls = (jousters.length + 1) * strategy_count * max_rounds;
+
   const main_key = main.model;
   model_usage[main_key] = {
-    input: (model_usage[main_key]?.input ?? 0) + main_calls * tokens_per_call,
-    output: (model_usage[main_key]?.output ?? 0) + main_calls * Math.ceil(tokens_per_call * 0.3),
+    input: (model_usage[main_key]?.input ?? 0) + main_lint_polish_calls * tokens_per_call,
+    output: (model_usage[main_key]?.output ?? 0) + main_lint_polish_calls * Math.ceil(tokens_per_call * 0.3),
   };
+  // scorer is either same model as main (merge) or a separate row.
+  const scorer_key = scorer_label;
+  if (scorer_key === main_key) {
+    model_usage[main_key] = {
+      input: (model_usage[main_key]?.input ?? 0) + scorer_calls * tokens_per_call,
+      output: (model_usage[main_key]?.output ?? 0) + scorer_calls * Math.ceil(tokens_per_call * 0.3),
+    };
+  } else {
+    model_usage[scorer_key] = {
+      input: (model_usage[scorer_key]?.input ?? 0) + scorer_calls * tokens_per_call,
+      output: (model_usage[scorer_key]?.output ?? 0) + scorer_calls * Math.ceil(tokens_per_call * 0.3),
+    };
+  }
   for (const j of jousters) {
     const key = j.model;
     const j_calls = max_rounds; // 1 mutation per round

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,6 +144,25 @@ export function get_jousters(config: JoustConfig): AgentConfig[] {
   return Object.values(config.agents).filter((a) => a.name !== "main");
 }
 
+// --- scorer agent (#51) ---
+//
+// when defaults.scorer_model is set, strategy score() calls use a
+// cloned main agent with the model field overridden. bootstrap stays
+// on real main. api_key, system, temperature inherit from main —
+// scorer_model is a model-id swap only.
+//
+// returns main unchanged when scorer_model is null/unset, so callers
+// can blindly thread `build_scorer_agent(main, cfg.scorer_model)` and
+// get the right behavior either way.
+export function build_scorer_agent(main: AgentConfig, scorer_model?: string): AgentConfig {
+  if (!scorer_model || scorer_model === main.model) return main;
+  return {
+    ...main,
+    name: `${main.name}-scorer`,
+    model: scorer_model,
+  };
+}
+
 // --- generate default rfc.yaml content ---
 
 // --- presets ---
@@ -370,6 +389,7 @@ export function generate_default_config(preset: Preset = "mixed"): string {
       plateau_k: 2,                  // strategy-scoring: rounds-flat threshold
       // workspace: ".",             // default: project dir. set to override
       // max_tool_steps: 10,         // cap tool-use round-trips per agent turn
+      // scorer_model: "claude-haiku-4-5",  // cheaper model for strategy scoring
     },
     agents: {
       main: {

--- a/src/run.ts
+++ b/src/run.ts
@@ -10,6 +10,7 @@ import {
   get_jousters,
   is_specialist_name,
   build_specialist_agent,
+  build_scorer_agent,
   preset_peer_pick,
   detect_preset,
 } from "./config";
@@ -102,8 +103,12 @@ function migrate_snowball(snow: Snowball): Snowball {
 // score a candidate via the configured strategies. returns null on
 // failure (network/parse errors) so the caller can fall back to legacy
 // lint-only semantics.
+//
+// the `scorer` arg is the agent to run strategy score() calls against.
+// it's main when defaults.scorer_model is unset; otherwise a cloned
+// main with the model swapped (#51). we never use this for bootstrap.
 async function score_candidate(
-  main: AgentConfig,
+  scorer: AgentConfig,
   strategies: StrategiesConfig,
   snowball: Snowball,
   candidate_draft: string,
@@ -117,7 +122,7 @@ async function score_candidate(
   }
 ): Promise<ScoringResult | null> {
   const run = async () =>
-    score_draft(main, strategies, snowball, candidate_draft, {
+    score_draft(scorer, strategies, snowball, candidate_draft, {
       signal: options.signal,
       tools: options.tools,
       max_tool_steps: options.max_tool_steps,
@@ -125,12 +130,12 @@ async function score_candidate(
       log_label: options.log_label,
     });
   if (options.tank) {
-    return await tank_execute("main", run);
+    return await tank_execute(scorer.name, run);
   }
   try {
     return await run();
   } catch (err: any) {
-    log_status("main", `scoring error: ${err.message}`);
+    log_status(scorer.name, `scoring error: ${err.message}`);
     return null;
   }
 }
@@ -318,6 +323,7 @@ export async function run(dir: string, options: RunOptions = {}): Promise<void> 
   // re-read config at round boundary
   let config = resolve_config(dir);
   let main = get_main_agent(config);
+  let scorer = build_scorer_agent(main, config.defaults.scorer_model);
   let jousters = get_jousters(config);
   const max_retries = config.defaults.max_retries;
   const max_rounds = config.defaults.max_rounds;
@@ -330,6 +336,9 @@ export async function run(dir: string, options: RunOptions = {}): Promise<void> 
     workspace_tools = create_workspace_tools(config.defaults.workspace);
     max_tool_steps = config.defaults.max_tool_steps;
     log(`workspace: ${config.defaults.workspace} (agents have file access)`);
+  }
+  if (scorer !== main) {
+    log(`scorer: ${scorer.model} (cheap-scorer override; bootstrap stays on ${main.model})`);
   }
 
   try {
@@ -349,6 +358,7 @@ export async function run(dir: string, options: RunOptions = {}): Promise<void> 
     // re-read config at round boundary (supports mid-flight edits)
     config = resolve_config(dir);
     main = get_main_agent(config);
+    scorer = build_scorer_agent(main, config.defaults.scorer_model);
     jousters = get_jousters(config);
     if (config.defaults.workspace) {
       workspace_tools = create_workspace_tools(config.defaults.workspace);
@@ -457,7 +467,7 @@ export async function run(dir: string, options: RunOptions = {}): Promise<void> 
           let scoring: ScoringResult | null = null;
           if (lint.valid && strategy_names.length > 0) {
             scoring = await score_candidate(
-              main,
+              scorer,
               strategies,
               snowball,
               mutation.draft,
@@ -788,7 +798,7 @@ export async function run(dir: string, options: RunOptions = {}): Promise<void> 
         let polish_scoring: ScoringResult | null = null;
         if (strategy_names.length > 0) {
           polish_scoring = await score_candidate(
-            main,
+            scorer,
             strategies,
             snowball,
             polish.draft,

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,10 @@ export interface JoustDefaults {
   // last (plateau_k + 1) rounds.
   plateau_epsilon?: number;
   plateau_k?: number;
+  // cheap-scorer override (#51). when set, strategy score() calls use
+  // this model id instead of main's. bootstrap stays on main. uses
+  // main's api_key (no separate key resolution).
+  scorer_model?: string;
 }
 
 export interface JoustConfig {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -6,6 +6,7 @@ import {
   is_specialist_name,
   get_specialist,
   build_specialist_agent,
+  build_scorer_agent,
   generate_default_config,
   normalize_gemini_env,
   has_gemini_key,
@@ -264,5 +265,36 @@ describe("MutationResultSchema", () => {
       summon: { specialist: "security", ask: "" },
     });
     expect(result.success).toBe(false);
+  });
+});
+
+
+describe("build_scorer_agent (#51)", () => {
+  const main = {
+    name: "main",
+    model: "claude-opus-4-6",
+    api_key: "$ANTHROPIC_API_KEY",
+    system: "lead architect",
+    temperature: 0.2,
+  } as const;
+
+  test("returns main unchanged when scorer_model is unset", () => {
+    expect(build_scorer_agent(main)).toBe(main);
+    expect(build_scorer_agent(main, undefined)).toBe(main);
+  });
+
+  test("returns main unchanged when scorer_model equals main.model", () => {
+    expect(build_scorer_agent(main, "claude-opus-4-6")).toBe(main);
+  });
+
+  test("returns a clone with model swapped when scorer_model differs", () => {
+    const scorer = build_scorer_agent(main, "claude-haiku-4-5");
+    expect(scorer.model).toBe("claude-haiku-4-5");
+    expect(scorer.api_key).toBe(main.api_key);
+    expect(scorer.system).toBe(main.system);
+    expect(scorer.temperature).toBe(main.temperature);
+    expect(scorer.name).toBe("main-scorer");
+    // does not mutate main
+    expect(main.model).toBe("claude-opus-4-6");
   });
 });


### PR DESCRIPTION
Implements #51. New optional `defaults.scorer_model` lets operators run strategy scoring against a cheaper model while keeping main on Opus (or whatever is preferred for bootstrap, lint, polish).

`build_scorer_agent(main, scorer_model?)` returns main as-is when unset/equal, clones with model swapped otherwise. Threaded into the jouster + polish scoring paths in run.ts.

`joust /plan` shows the scorer line and splits cost between main and scorer when they differ.

148 tests pass. Binary compiles. Refs: #42, #51.