### PR TITLE
fix(types): include declined_strategies + pending_summon in SnowballSchema

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,10 @@ export const SnowballSchema = z.object({
   best_draft: z.string().optional(),
   best_scoring: z.any().optional(),
   aggregate_history: z.array(z.number()).optional(),
+  // visibility (#50) + specialist carryover (#52). loosely validated;
+  // run.ts is the source of truth for the shape.
+  declined_strategies: z.any().optional(),
+  pending_summon: z.any().optional(),
 });
 
 export const HistoryEntrySchema = z.object({


### PR DESCRIPTION
Hotfix found during phase-2 dogfood. The two new optional fields landed in #55 and #57 were declared on the TS `Snowball` interface but not on the zod `SnowballSchema`. `safeParse` strips unknown keys by default, so `read_latest_history` silently dropped both fields when reloading post-bootstrap history entries.

Visible symptoms:
- `declined_strategies` showed at `/init` but disappeared from `/status` after the first mutation.
- `pending_summon` survived only within a single run; resumes wouldn't see it.

Loose validation via `z.any().optional()`, same pattern as strategies / best_scoring. 156 tests pass.