### PR TITLE
feat: agent-installable joust — release binaries + install.sh + Claude skill (#60)

### DIFF
--- a/.claude/skills/joust/SKILL.md
+++ b/.claude/skills/joust/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: joust
+description: Run joust — an adversarial architecture compiler that uses two antagonistic LLMs plus pluggable scoring strategies. Use only when the user types one of `/joust draft`, `/joust pickup`, `/joust review`, or `/joust status`. Do NOT invoke implicitly.
+---
+
+# joust
+
+Joust is a CLI binary that takes a prompt and runs an adversarial loop: two LLMs from different providers iteratively refine a draft, with pluggable scoring strategies (rubric, invariants, color) selecting the best output. Source: https://github.com/ahoward/joust.
+
+This skill is a thin wrapper. The real work lives in the binary. The skill knows when to reach for joust, how to install it, and how to translate its `--json` output back into conversation.
+
+## Hard rules
+
+1. **Explicit only.** This skill runs only when the user types a `/joust …` command. Never fire from casual mentions of "design" or "architecture" in conversation.
+2. **Binary version contract.** This skill requires `joust >= 0.2.0`. Each subcommand checks `joust --version` and re-installs if the binary is missing or out of range. Never proceed against an older joust.
+3. **Trust the binary, don't reimplement it.** All loop logic, scoring math, file locking, and provider orchestration lives in the binary. The skill never mutates `.joust/<slug>/` directly. If a behavior change is needed, file an issue against joust.
+4. **Use `--json` for state reads.** When this skill needs to know what's in a snowball, call `joust /status --json` or `joust /export --json` and parse the JSON. Never grep human-formatted stdout.
+5. **Workspace = current repo.** Joust runs against `process.cwd()` as its workspace by default. The skill should `cd` to the project root before invoking joust.
+
+## Install bootstrap (run by every subcommand)
+
+Each subcommand begins by ensuring `joust` is available and compatible. The pattern:
+
+```sh
+# 1. find joust on PATH or via prior JOUST_BINARY hint
+JOUST="${JOUST_BINARY:-$(command -v joust 2>/dev/null || true)}"
+
+# 2. version check (skill requires >= 0.2.0 < 1.0.0)
+NEEDS_INSTALL=1
+if [ -n "$JOUST" ]; then
+  CURRENT="$("$JOUST" --version 2>/dev/null | sed 's/^v//')"
+  case "$CURRENT" in
+    0.[2-9]*|0.[1-9][0-9]*) NEEDS_INSTALL=0 ;;
+  esac
+fi
+
+# 3. install if missing or out of range. capture JOUST_BINARY hint if PATH unset.
+if [ "$NEEDS_INSTALL" = "1" ]; then
+  INSTALL_OUTPUT="$(curl -fsSL https://github.com/ahoward/joust/releases/latest/download/install.sh | sh)"
+  echo "$INSTALL_OUTPUT"
+  HINT="$(echo "$INSTALL_OUTPUT" | grep -oE 'JOUST_BINARY=.*' | tail -1 | cut -d= -f2)"
+  JOUST="${HINT:-$(command -v joust 2>/dev/null || echo "$HOME/.local/bin/joust")}"
+fi
+
+# 4. proceed with the actual command
+"$JOUST" /<command> ...
+```
+
+When a subcommand needs to invoke joust, run that bootstrap first, then the command, in a single shell invocation. Do not split across tool calls.
+
+## API keys
+
+Joust reads provider API keys from environment variables (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`). The skill does not manage keys. If joust errors with "missing env var X", surface that to the user — they need to set it themselves (typically via `.envrc`, `direnv`, or shell init).
+
+## Routing
+
+Route to the matching command playbook in `commands/`:
+
+| User types | Playbook |
+|---|---|
+| `/joust draft <prompt>` | `commands/draft.md` |
+| `/joust pickup [dir]` | `commands/pickup.md` |
+| `/joust review [dir]` | `commands/review.md` |
+| `/joust status [dir]` | `commands/status.md` |
+
+If the user types `/joust` with no subcommand, list the four subcommands and ask which they want.
+
+If the user types `/joust <unknown>`, list the four valid subcommands.
+
+## When NOT to invoke joust
+
+- Trivial single-step tasks. "Rename foo to bar" doesn't need adversarial review.
+- Pure exploration. "Look at this codebase and tell me what's there." Joust is for *producing* artifacts, not *understanding* them.
+- Anything that could be done in one or two LLM turns directly. Joust adds 5-30 minutes of wall time and N agent calls; only pull it in when iterative refinement is genuinely warranted.
+
+## Output handling
+
+Every joust subcommand surfaces back to the user in conversation. Never just dump `--json` raw — translate into a paragraph:
+- Configured strategies (which apply, which declined and why).
+- Best aggregate + color tier (when set).
+- Trajectory if multi-round.
+- Pending summon if any (a specialist is mid-attempt).
+- Where the artifacts live (`.joust/<slug>/`).

--- a/.claude/skills/joust/commands/draft.md
+++ b/.claude/skills/joust/commands/draft.md
@@ -1,0 +1,73 @@
+# /joust draft
+
+User intent: take a prompt, produce a refined artifact via joust's adversarial loop.
+
+## Args
+
+- `<prompt>` — required. The thing to draft. Can be a string ("design X") or a path to a file containing the prompt.
+- `--rounds N` (optional) — override `max_rounds` for this run. Otherwise joust uses the config default.
+- `--scorer <model>` (optional) — set `defaults.scorer_model` for cost savings. Common: `claude-haiku-4-5`.
+
+## Steps
+
+### 1. Confirm before spending money
+
+Joust runs cost real LLM API spend. Before invoking:
+- Surface the prompt back to the user.
+- Note: this will run `joust draft "<prompt>"` against the currently configured agent panel.
+- Estimate: each round = ~5-10 minutes wall time, $0.10–$2 depending on model + draft size + strategies.
+- Ask the user to confirm before running.
+
+If the user has already explicitly said "go" or "do it" with the prompt, skip the explicit confirmation but still note the cost expectation.
+
+### 2. Install bootstrap
+
+Run the bootstrap from `SKILL.md`. Result: `JOUST` is set to an absolute path to the binary.
+
+### 3. Pre-flight check
+
+- `pwd` — confirm we're in the project root (so the workspace is right).
+- `echo $ANTHROPIC_API_KEY` (just the prefix, not the value) to confirm at least one provider key is set. If no keys are set, surface the error before joust dies.
+
+### 4. Run
+
+```sh
+"$JOUST" /draft "$prompt"
+```
+
+`/draft` does init + run in one shot. Joust will:
+- Bootstrap strategies (rubric, invariants, color — strategies that don't apply will decline and log it).
+- Run the adversarial loop for `max_rounds` rounds.
+- Stop early if plateau detected or all strategies converge to top score.
+- Emit the final draft on stdout.
+
+If the user supplied `--rounds N` or `--scorer <model>`, edit `.joust/<slug>/config.json` between init and run:
+
+```sh
+"$JOUST" /init "$prompt"             # init only, returns dir on stdout
+DIR="<the dir from init output>"
+# patch config.json with the overrides...
+"$JOUST" /run "$DIR"
+```
+
+### 5. Report back
+
+After the run completes, fetch structured status:
+
+```sh
+"$JOUST" /status "$DIR" --json
+```
+
+Translate to conversation. Show:
+- Where the artifacts live (`$DIR`).
+- Configured strategies + which declined.
+- Best aggregate + color tier.
+- Trajectory if multi-round.
+- Recommend next: `/joust review` to see scores, or open the export draft.
+
+### 6. Failure handling
+
+- **Network errors / API rate limits.** Joust has tank mode. Retry suggestion: `joust /run $DIR --tank --timebox 30m`.
+- **Provider key missing.** Surface to user. Do not try to set keys yourself.
+- **Lock conflict (`acquire_lock` failed).** Another joust is running against the same dir. Tell the user; do not force.
+- **Specialist hit `.needs-attention`.** A specialist exhausted retries. Surface the marker file contents.

--- a/.claude/skills/joust/commands/pickup.md
+++ b/.claude/skills/joust/commands/pickup.md
@@ -1,0 +1,59 @@
+# /joust pickup
+
+User intent: resume an in-progress joust run, or look at the latest one in the cwd.
+
+## Args
+
+- `[dir]` — optional. The `.joust/<slug>/` dir to resume. If absent, find the most recent one in `./.joust/`.
+
+## Steps
+
+### 1. Install bootstrap
+
+From SKILL.md.
+
+### 2. Resolve target dir
+
+```sh
+if [ -z "$1" ]; then
+  # find most recent .joust/<slug>/ dir
+  DIR="$(ls -td .joust/*/ 2>/dev/null | head -1)"
+  if [ -z "$DIR" ]; then
+    echo "no .joust/<slug>/ dirs found in $(pwd)" >&2
+    exit 1
+  fi
+else
+  DIR="$1"
+fi
+```
+
+If multiple `.joust/<slug>/` exist and the user didn't specify, ask which one.
+
+### 3. Read state
+
+```sh
+"$JOUST" /status "$DIR" --json
+```
+
+Parse the JSON. Decide what's actionable:
+
+| State | Action |
+|---|---|
+| `pending_summon` is set | Tell the user a specialist is mid-attempt. Resuming will re-run that specialist with the prior rejection feedback. |
+| `aggregate_history` length < `max_rounds` and last status was not "complete" | Run was interrupted. Suggest `joust /run $DIR` to continue. |
+| `best_aggregate == 1.0` and trajectory plateaued | Done. Nothing to resume. Suggest `/joust review` or open export. |
+| `.needs-attention` file exists | Surface it. The run is paused on a fixable problem. |
+
+### 4. Confirm and resume
+
+Surface the state summary, the proposed next action, and ask the user to confirm before running. Common next actions:
+
+- `joust /run $DIR --timebox 30m` — continue the loop.
+- `joust /run $DIR --tank --timebox 1h` — continue with retry tolerance.
+- Edit `$DIR/config.json` first, then run (e.g. bump max_rounds, swap scorer_model).
+
+Do not run automatically. Confirmation is the rule.
+
+### 5. After resume completes, report
+
+Same as `/joust draft` step 5.

--- a/.claude/skills/joust/commands/review.md
+++ b/.claude/skills/joust/commands/review.md
@@ -1,0 +1,66 @@
+# /joust review
+
+User intent: see how the latest joust run scored — strategies, dimensions, where it lost points.
+
+## Args
+
+- `[dir]` — optional. Defaults to most recent `.joust/<slug>/` in cwd.
+
+## Steps
+
+### 1. Install bootstrap
+
+From SKILL.md.
+
+### 2. Resolve dir
+
+Same as `pickup` step 2.
+
+### 3. Fetch structured export
+
+```sh
+"$JOUST" /export "$DIR" --json
+```
+
+JSON has:
+- `draft` — the best draft text.
+- `best_aggregate` — overall score.
+- `best_color_tier` — `red`/`yellow`/`green`/`null`.
+- `scorecards[]` — per-strategy:
+  - `strategy` name
+  - `aggregate` (0..1)
+  - `dimensions[]` with `name`, `score`, `max`, `weight`, `floor`, `rationale`
+  - optional `color_tier` (only on color strategy)
+- `strategies` — the configured strategies (rubric dims, invariants rules, color question).
+
+### 4. Render to conversation
+
+Format as readable markdown:
+
+```markdown
+## joust review — <DIR>
+
+**Best aggregate:** 0.847 (color tier: green)
+
+**Strategies:**
+- rubric (aggregate 0.81)
+  - clarity: 8/13 — "concise but missing examples"
+  - security: 13/13 — "covers all listed threats"
+  - completeness: 5/13 — "skips error cases"
+- invariants (aggregate 0.92)
+  - MUST: atomic writes ✓
+  - MUST: no secrets in logs ✓
+  - SHOULD: prefer existing utils ✗ — "introduced new helper"
+
+**Where it lost points:**
+- rubric/completeness: 5/13 — error cases not addressed
+- invariants/SHOULD-prefer-existing-utils: 0/13 — new helper introduced
+
+**To improve:** could re-run with feedback (`/joust pickup` then add a human directive in config), or accept and ship.
+```
+
+Tailor the rendering based on which strategies are configured. If only one strategy, simplify. If no scoring at all (legacy run), say so and suggest the operator re-init to get strategies.
+
+### 5. No mutation
+
+This command is read-only. Never edit config.json, history, or run anything from review.

--- a/.claude/skills/joust/commands/status.md
+++ b/.claude/skills/joust/commands/status.md
@@ -1,0 +1,46 @@
+# /joust status
+
+User intent: short summary of the latest joust run — what's happening, what's next.
+
+This is the lightweight version of `/joust review`. Use status when the user wants a one-glance summary; use review when they want to see scores in detail.
+
+## Args
+
+- `[dir]` — optional. Defaults to most recent `.joust/<slug>/` in cwd.
+
+## Steps
+
+### 1. Install bootstrap
+
+From SKILL.md.
+
+### 2. Resolve dir
+
+Same as `pickup` step 2.
+
+### 3. Get JSON status
+
+```sh
+"$JOUST" /status "$DIR" --json
+```
+
+### 4. One-paragraph summary to conversation
+
+Render concise:
+
+```
+joust @ <DIR>: step 7 (main/polish, accepted), best agg=0.847 tier=green,
+3 rounds done, strategies: rubric+invariants. No pending summon.
+```
+
+If something is actionable (pending summon, plateau, or `.needs-attention`), call it out:
+
+```
+joust @ <DIR>: step 4 (peer/mutation, rejected). Pending summon: legal
+specialist asked about jurisdiction (1 prior attempt failed for
+"missed clause"). /joust pickup will retry it.
+```
+
+### 5. No mutation, no run
+
+Read-only command. For action, suggest `/joust pickup` or `/joust review`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "tag to build (e.g. v0.2.0). leave blank to build HEAD without releasing"
+        required: false
+
+jobs:
+  build:
+    name: build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+            asset: joust-linux-x64
+          - os: macos-latest
+            target: darwin-arm64
+            asset: joust-darwin-arm64
+          - os: macos-13
+            target: darwin-x64
+            asset: joust-darwin-x64
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: install bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: install deps
+        run: bun install --frozen-lockfile || bun install
+
+      - name: build
+        run: bun build ./src/cli.ts --compile --outfile ${{ matrix.asset }}
+
+      - name: smoke test --version
+        run: ./${{ matrix.asset }} --version
+
+      - name: compute sha256 (linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sha256sum ${{ matrix.asset }} > ${{ matrix.asset }}.sha256
+
+      - name: compute sha256 (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: shasum -a 256 ${{ matrix.asset }} > ${{ matrix.asset }}.sha256
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: |
+            ${{ matrix.asset }}
+            ${{ matrix.asset }}.sha256
+          if-no-files-found: error
+
+  release:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: stage release files
+        run: |
+          mkdir -p release
+          for d in dist/joust-*/; do
+            cp "$d"/* release/
+          done
+          # ship install.sh as a release asset too so users can pin a version
+          cp install.sh release/install.sh
+          ls -la release/
+
+      - name: publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -117,9 +117,30 @@ joust is designed to be invoked from within AI coding agents like Claude Code,
 Gemini CLI, Cursor, Windsurf, Cline, etc. the `/` command syntax was designed
 for this -- it mirrors slash commands in Claude Code and similar tools.
 
-### Claude Code setup
+### Claude Code: skill (recommended)
 
-add a slash command to your project:
+joust ships a Claude Code skill at `.claude/skills/joust/`. clone this repo,
+start a Claude Code session in it, and the agent will discover the skill
+automatically. four subcommands:
+
+```
+/joust draft <prompt>    # bootstrap + run, with confirmation
+/joust pickup [dir]      # resume the latest in-progress run
+/joust review [dir]      # show scores in detail
+/joust status [dir]      # one-line summary
+```
+
+the skill's first invocation auto-installs the joust binary if missing,
+verifies its checksum, and pins to a compatible version range. uses
+`joust /status --json` and `joust /export --json` to read state, never
+parses human-formatted stdout.
+
+if you want the skill available in any repo (not just this one), copy
+`.claude/skills/joust/` to `~/.claude/skills/joust/`.
+
+### Claude Code: simple slash command
+
+if you prefer a thin passthrough instead of the skill, add a slash command to your project:
 
 ```bash
 mkdir -p .claude/commands

--- a/install.sh
+++ b/install.sh
@@ -1,76 +1,138 @@
-#!/usr/bin/env bash
-#
-# joust installer
+#!/bin/sh
+# joust installer — downloads a release binary, verifies sha256, places it on PATH.
 #
 # usage:
-#   curl -fsSL https://raw.githubusercontent.com/ahoward/joust/main/install.sh | bash
+#   curl -fsSL https://github.com/ahoward/joust/releases/latest/download/install.sh | sh
 #
-set -euo pipefail
+# env overrides:
+#   JOUST_VERSION=v0.2.0      pin a specific version (default: latest)
+#   JOUST_INSTALL_DIR=/path   install location (default: $HOME/.local/bin)
+#
+# output (when install dir is NOT on $PATH):
+#   the last line of stdout is `JOUST_BINARY=<absolute_path>` so a calling
+#   agent / skill can invoke joust by absolute path even without a PATH update.
+
+set -eu
 
 REPO="ahoward/joust"
-INSTALL_DIR="${JOUST_INSTALL_DIR:-/usr/local/bin}"
-BINARY="joust"
+VERSION="${JOUST_VERSION:-latest}"
+INSTALL_DIR="${JOUST_INSTALL_DIR:-$HOME/.local/bin}"
 
-# --- detect platform ---
+# --- detect platform/arch ---
 
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 
-case "$OS" in
-  linux)  OS="linux" ;;
-  darwin) OS="darwin" ;;
-  *)      echo "error: unsupported OS: $OS" >&2; exit 1 ;;
+case "$OS-$ARCH" in
+  linux-x86_64)  TARGET="linux-x64" ;;
+  darwin-arm64)  TARGET="darwin-arm64" ;;
+  darwin-x86_64) TARGET="darwin-x64" ;;
+  *)
+    echo "joust: unsupported platform $OS-$ARCH" >&2
+    echo "joust: supported: linux-x64, darwin-arm64, darwin-x64" >&2
+    exit 1
+    ;;
 esac
 
-case "$ARCH" in
-  x86_64|amd64)  ARCH="x64" ;;
-  arm64|aarch64) ARCH="arm64" ;;
-  *)             echo "error: unsupported architecture: $ARCH" >&2; exit 1 ;;
-esac
+ASSET="joust-$TARGET"
 
-ASSET="joust-${OS}-${ARCH}"
+# --- resolve release URL ---
 
-echo "joust installer"
-echo "  platform: ${OS}-${ARCH}"
-echo "  install:  ${INSTALL_DIR}/${BINARY}"
-echo ""
+if [ "$VERSION" = "latest" ]; then
+  BASE="https://github.com/$REPO/releases/latest/download"
+else
+  BASE="https://github.com/$REPO/releases/download/$VERSION"
+fi
 
-# --- fetch latest release tag ---
+BINARY_URL="$BASE/$ASSET"
+SHA_URL="$BASE/$ASSET.sha256"
 
-TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
+# --- platform-aware sha256 verification ---
 
-if [ -z "$TAG" ]; then
-  echo "error: could not determine latest release" >&2
+verify_sha256() {
+  expected="$1"
+  file="$2"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$file" | awk '{print $1}')"
+  else
+    echo "joust: neither sha256sum nor shasum found; cannot verify" >&2
+    return 1
+  fi
+  if [ "$expected" != "$actual" ]; then
+    echo "joust: checksum mismatch for $file" >&2
+    echo "  expected: $expected" >&2
+    echo "  actual:   $actual" >&2
+    return 1
+  fi
+}
+
+# --- download to a temp dir, verify, then atomic mv ---
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT INT TERM
+
+echo "joust: downloading $ASSET from $BINARY_URL"
+if ! curl --fail --silent --show-error -L "$BINARY_URL" -o "$TMPDIR/joust"; then
+  echo "joust: download failed" >&2
   exit 1
 fi
 
-echo "  version:  ${TAG}"
-
-URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET}"
-
-# --- download ---
-
-echo ""
-echo "downloading ${URL}..."
-
-TMPFILE=$(mktemp)
-trap 'rm -f "$TMPFILE"' EXIT
-
-curl -fSL --progress-bar -o "$TMPFILE" "$URL"
-
-chmod +x "$TMPFILE"
-
-# --- install ---
-
-if [ -w "$INSTALL_DIR" ]; then
-  mv "$TMPFILE" "${INSTALL_DIR}/${BINARY}"
-else
-  echo ""
-  echo "installing to ${INSTALL_DIR} (requires sudo)..."
-  sudo mv "$TMPFILE" "${INSTALL_DIR}/${BINARY}"
+echo "joust: downloading checksum"
+if ! curl --fail --silent --show-error -L "$SHA_URL" -o "$TMPDIR/joust.sha256"; then
+  echo "joust: checksum download failed" >&2
+  exit 1
 fi
 
-echo ""
-echo "installed: $(${INSTALL_DIR}/${BINARY} --help 2>&1 | head -1)"
-echo ""
-echo "done. run: joust --help"
+EXPECTED_SHA="$(awk '{print $1}' "$TMPDIR/joust.sha256")"
+if [ -z "$EXPECTED_SHA" ]; then
+  echo "joust: empty checksum file from $SHA_URL" >&2
+  exit 1
+fi
+
+echo "joust: verifying checksum"
+if ! verify_sha256 "$EXPECTED_SHA" "$TMPDIR/joust"; then
+  exit 1
+fi
+
+# --- ensure install dir exists, place binary atomically ---
+
+if ! mkdir -p "$INSTALL_DIR"; then
+  echo "joust: cannot create $INSTALL_DIR" >&2
+  exit 1
+fi
+
+if [ ! -w "$INSTALL_DIR" ]; then
+  echo "joust: $INSTALL_DIR is not writable by $(id -un)" >&2
+  echo "joust: set JOUST_INSTALL_DIR=<path> to override" >&2
+  exit 1
+fi
+
+chmod +x "$TMPDIR/joust"
+mv "$TMPDIR/joust" "$INSTALL_DIR/joust"
+
+# --- verify install ---
+
+if ! "$INSTALL_DIR/joust" --version >/dev/null 2>&1; then
+  echo "joust: installed binary failed --version probe at $INSTALL_DIR/joust" >&2
+  exit 1
+fi
+
+INSTALLED="$("$INSTALL_DIR/joust" --version)"
+echo "joust: installed $INSTALLED at $INSTALL_DIR/joust"
+
+# --- PATH detection ---
+# if the install dir is on $PATH, we're done. otherwise emit a parseable
+# JOUST_BINARY=<path> line so a calling agent can capture it.
+
+case ":${PATH:-}:" in
+  *":$INSTALL_DIR:"*)
+    : # on PATH; nothing more to do
+    ;;
+  *)
+    echo "joust: $INSTALL_DIR is not on \$PATH; add this to your shell init:"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo "JOUST_BINARY=$INSTALL_DIR/joust"
+    ;;
+esac

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "joust",
+  "version": "0.2.0",
   "type": "module",
   "private": true,
   "main": "src/cli.ts",

--- a/spool/gh/issue/60-agent-installable/README.md
+++ b/spool/gh/issue/60-agent-installable/README.md
@@ -1,0 +1,54 @@
+# #60 — agent-installable joust
+
+**Spec:** https://github.com/ahoward/joust/issues/60
+**Status:** ready-for-review (release workflow needs first tag to fully smoke-test)
+**Branch:** `agent-installable`
+
+## Plan
+
+Single PR. Four coupled deliverables in dependency order:
+
+1. **Binary changes** to `src/cli.ts`: `--version`, `/status --json`, `/export --json`.
+2. **GH Actions workflow** `.github/workflows/release.yml` — build matrix with `macos-latest` (arm64), `macos-13` (x64), `ubuntu-latest` (linux-x64). Upload binaries + SHA256 sidecars on `git tag v*`.
+3. **`install.sh`** — committed at repo root, also published as a release asset. Detects platform, downloads + verifies sha256, atomic mv to `~/.local/bin/joust` (override via `JOUST_INSTALL_DIR`). `set -eu`, `curl --fail`, `mkdir -p`. Outputs `JOUST_BINARY=<path>` when install dir isn't on `$PATH` so the skill can capture it.
+4. **`.claude/skills/joust/`** — SKILL.md + commands/{draft,pickup,review,status}.md. Every command opens with an install-bootstrap pattern (check version, re-install if out of compat range, run command).
+
+## Adversarial review
+
+Three rounds with Gemini. Outputs at `r1.md` / `r1-gemini.md` / `r2.md` / `r2-gemini.md` / `r3.md`. Round 3 is the final plan; this README executes it.
+
+## Done
+
+- `package.json` gains `"version": "0.2.0"`. Imported into cli.ts via `import pkg from "../package.json" with { type: "json" }`.
+- `src/cli.ts`: `--version` / `-v` / `/version` all print `v0.2.0` to stdout. Goes through dispatch like other commands.
+- `src/cli.ts`: `--json` flag parsed, threaded to status/export.
+- `src/commands.ts::status(dir, { json })`: emits `schema_version: 1` JSON shape with step/actor/action, history counts, configured strategies, declined strategies, best aggregate + tier, scorecards, aggregate_history, pending_summon, draft_chars, critique_count.
+- `src/commands.ts::export_draft(dir, { json })`: emits `schema_version: 1` JSON with draft + best aggregate + scorecards + strategies.
+- `.github/workflows/release.yml`: build matrix with `ubuntu-latest`/`macos-latest`/`macos-13` for linux-x64/darwin-arm64/darwin-x64. Each build produces `joust-<target>` + `joust-<target>.sha256`. Release job runs only on `v*` tag push; uploads all six artifacts plus `install.sh` to the release.
+- `install.sh` (POSIX `sh`, not bash): `set -eu`, detects platform/arch, downloads binary + checksum from the release with `curl --fail`, verifies sha256 (handles both `sha256sum` linux and `shasum -a 256` darwin), atomic mv into `~/.local/bin/joust` (or `$JOUST_INSTALL_DIR`), runs `--version` to verify, emits `JOUST_BINARY=<path>` last-line if install dir not on PATH for agent capture.
+- `.claude/skills/joust/`: SKILL.md (hard rules, install bootstrap pattern, routing) + commands/{draft,pickup,review,status}.md. Skill enforces version range (>= 0.2.0 < 1.0.0) and reinstalls if drift. Always uses `--json` for state reads.
+- README adds "Claude Code: skill (recommended)" section above the existing slash-command instructions.
+- 156 tests pass, binary compiles, syntax-checked install.sh.
+
+## Next
+
+Nothing — ready to merge after review. Post-merge: tag `v0.2.0` to trigger the release workflow, verify all six artifacts + install.sh land on the GitHub Release. Final smoke test: clean machine, `curl | sh`, install joust, run a draft.
+
+## Pitfalls
+
+- **macOS Gatekeeper.** First run of an unsigned binary on macOS triggers a quarantine warning. Document. Real fix is notarization, deferred.
+- **Bun cross-compile for darwin from Linux is unreliable.** Plan uses native macOS runners. Don't try to build darwin from Linux.
+- **`--json` shape is now a contract.** Once shipped, breaking changes need a major version bump. Plan documents this in SKILL.md and the README.
+- **`curl | sh` security.** Sha256 verification is the trust boundary. Sigstore signing is the next level; deferred.
+- **Re-install upgrades.** Install script is idempotent — re-running upgrades to latest. Skill enforces compat range and forces re-install if drift.
+
+## Open questions
+
+- Sha256sum on macOS uses a different invocation (`shasum -a 256`); install script must handle both.
+- Should `install.sh` accept a target version via env (`JOUST_VERSION=v0.2.0`)? Yes, both for skill compat enforcement and operator pinning.
+
+## Versioning policy
+
+- v0.x: `--json` shape may break with minor bumps.
+- v1.0+: `--json` is the public API.
+- Skill SKILL.md declares the compat range.

--- a/spool/gh/issue/60-agent-installable/r1-gemini.md
+++ b/spool/gh/issue/60-agent-installable/r1-gemini.md
@@ -1,0 +1,29 @@
+This plan is a well-intentioned but naive attempt to bolt an "agent-friendly" facade onto a developer-centric workflow. It prioritizes the author's convenience over the agent's operational needs, creating a brittle system whose failure modes will frustrate any user, human or AI. The core premise—that an agent can reliably build a 100MB binary from source as a first-time setup step—is fundamentally flawed.
+
+Here are the substantive critiques.
+
+### 1. The "Build-from-Source" Install is a House of Cards for an Agent
+
+The plan's decision to make a 30+ second, multi-dependency build process the *default* installation path for an agent is malpractice. An agent's environment is not a developer's laptop. It requires speed, determinism, and minimal dependencies.
+
+*   **Failure Mode: Environment Mismatch.** The script checks for `bun`, but what about the correct version of `bun`? What about system libraries `bun` or the TypeScript compilation might depend on? What about available memory? A build can fail for a dozen reasons (`OOM killer`, `glibc` mismatch, network flakiness fetching dependencies) that are entirely opaque to the agent. The script's proposed error handling is a naive "error with a hint," which is useless to an agent that can't read, reason about, and act on arbitrary error messages.
+*   **Failure Mode: Timeouts and State Confusion.** An agent operating within a turn-based or time-limited execution window cannot afford to wait for a compilation that might take 30 seconds on an M3 Max but 3 minutes on a constrained cloud VM. The agent will likely time out, lose context, and report a generic failure, leaving the user's file system in a partially-installed state.
+*   **The Solution is Obvious and Deferred.** Phase 2 is not "eventual"; it is the *only acceptable Phase 0*. The primary installation path for an agent must be downloading a pre-compiled, statically-linked binary. Building from source should be the deep-fallback, expert-only option, not the front door.
+
+### 2. The Skill is a "Leaky Abstraction," Not a "Thin Wrapper"
+
+The plan claims the skill is a "thin wrapper" that remains "orthogonal to the binary." This is a fantasy. The moment a skill's command, like `review.md` or `status.md`, is responsible for parsing and translating the binary's output, it becomes a fragile, tightly-coupled presentation layer.
+
+*   **Implicit Contract, Guaranteed Breakage.** The skill's markdown files will inevitably make assumptions about the structure, format, and even color codes of `joust`'s stdout. When the binary's output format changes—even slightly, like reordering a column in `joust status`—the skill will break silently. The agent will receive malformed data, misinterpret the state of the system, and give the user incorrect information. This creates a hidden maintenance burden where every CLI change requires a corresponding, un-versioned change to the markdown skill.
+*   **Complexity Leakage.** The binary's complexity isn't being hidden; it's being smeared into the skill. Flags, arguments, and state management concepts (`.joust/<slug>/`) are all exposed. The skill doesn't simplify the agent's interaction; it just forces the agent to learn `joust`'s interface via a layer of markdown indirection. A truly effective skill would offer a higher-level, semantic interface (e.g., "summarize the results of the last run") that abstracts away the specific commands and output parsing. This plan does the opposite.
+
+### 3. The Agent's First-Contact Experience is Clumsy and Error-Prone
+
+The proposed user flow—"if `joust` isn't on PATH, invoke `/joust install` first"—fatally misunderstands an agent's operational logic. This is not a seamless experience; it's a manual, two-step process that invites failure.
+
+*   **Discovery Failure.** An agent's first instinct upon being asked to "draft a blog post using joust" will be to invoke `/joust draft`. The skill's response, "first, run this other command," is a conversational dead-end. A robust skill should handle its own dependencies transparently. The `draft.md` command itself should contain the logic: "check if `joust` exists; if not, install it; then execute the draft command." Forcing a separate, user- or agent-invoked installation command is brittle and poor UX.
+*   **The `PATH` Problem is a Dealbreaker.** The plan's solution to `~/.local/bin` not being on `PATH` is to "warn." An agent cannot act on this warning. It cannot edit a user's `.zshrc` or `.bash_profile`. It will simply fail on the next step when it tries to execute `joust`. This isn't a warning; it's a fatal, unrecoverable error for the agent. The install script *must* either place the binary on a path that is guaranteed to be in the default `PATH` (like `/usr/local/bin`, which requires `sudo` and is rightly avoided) or provide the agent with the full, absolute path to the binary upon successful installation so it can be invoked directly. The current plan punts on the single most common point of failure for CLI tool installation.
+
+***
+
+**Rethink.** This plan should not ship. It optimizes for the developer's desire to avoid CI/CD at the direct expense of the agent's (and user's) need for a reliable, deterministic, and seamless experience. The core premise of a source-build install is wrong for this context. Phase 2 is not optional; it is the mandatory starting point. The install script must be rewritten to be a downloader for pre-compiled release artifacts. Only then can a skill be built on top of that reliable foundation, and that skill must be designed to handle its own installation dependencies transparently rather than forcing a fragile, multi-step workflow on the agent.

--- a/spool/gh/issue/60-agent-installable/r1.md
+++ b/spool/gh/issue/60-agent-installable/r1.md
@@ -1,0 +1,85 @@
+# Plan: make joust "point an agent at this repo and go"
+
+Three phases. Phase 0 is the smallest viable thing; phase 1 is the
+agent-ergonomics layer; phase 2 is release infrastructure.
+
+## Phase 0 — `dev/install` (build-from-source)
+
+A shell script in `dev/install` that:
+1. Detects whether `bun` is on PATH. If not, error with a one-line install hint.
+2. Runs `bun build ./src/cli.ts --compile --outfile ~/.local/bin/joust`.
+3. Verifies `~/.local/bin` is on PATH. Warns if not.
+4. Prints `joust --help` first line as a smoke test.
+
+Plus a "Use with Claude Code" section in README pointing at it.
+
+No CI, no release artifacts. Single-command install for any human or
+agent that has cloned the repo.
+
+## Phase 1 — Claude Code skill at `.claude/skills/joust/`
+
+Mirror the structure spool evolved at `ahoward/spool/.claude/skills/spool/`:
+
+```
+.claude/skills/joust/
+  SKILL.md                # what joust is, when to use it, install bootstrap
+  commands/
+    install.md            # one-time install — calls dev/install if bin missing
+    draft.md              # `joust draft <prompt>` wrapper, bootstrap + run
+    pickup.md             # resume a partial run from .joust/<slug>/
+    review.md             # parse best_scoring + scorecards into conversation
+    status.md             # call `joust status` and translate output
+```
+
+SKILL.md opens with "if `joust` isn't on PATH, invoke /joust install first."
+
+Cloning the joust repo + starting a Claude Code session there means the
+agent discovers the skill and can run joust on appropriate prompts.
+First use auto-installs the binary.
+
+## Phase 2 — release infrastructure (eventual)
+
+When the project has users, add:
+
+- GitHub Actions workflow on `git tag v*`:
+  - Build for `linux-x64`, `darwin-arm64`, `darwin-x64`.
+  - Attach binaries to a GitHub Release.
+- `dev/install` prefers downloading the matching release binary over
+  building from source when on a tagged commit / when bun isn't present.
+
+Phase 2 is deferred until the project has users beyond the author.
+
+## Key design decisions
+
+1. **Skill in the joust repo, not separate repo.** Pointing an agent at
+   the joust repo gives them the skill + source. Generalize later if
+   the skill earns its own life.
+2. **`.claude/skills/joust/`** — Claude-specific path. Other agents
+   (Cursor, Cline) won't find it. Acceptable for now since Claude is
+   the primary target; generalize when a second agent matters.
+3. **Install location: `~/.local/bin/joust`.** Standard XDG-ish path.
+   No sudo needed. User likely has it on PATH already; warn if not.
+4. **No skill replaces the binary.** Phase-2 LLM orchestration in joust
+   is too cost/state/locking-sensitive to do in markdown turns. Skill
+   is a thin wrapper for "agent uses joust"; binary is the engine.
+5. **Build-from-source is the v0 install path.** Bun + 30 seconds. No
+   CI burden. Releases come when there's demand.
+
+## Why this is the right shape
+
+- Self-contained: clone the repo, start an agent session, go.
+- No `npm install -g` or `cargo install` step required upfront — the
+  skill handles install on first invocation.
+- Skill stays small (~6 markdown files) and orthogonal to the binary.
+- Future-portable: when other agents matter, the skill conventions can
+  copy over with minor tweaks.
+- The install script is independently useful (a human can run it).
+
+## What I'm not doing
+
+- Not publishing to a registry (npm, crates, brew). Premature.
+- Not building a system-wide service or daemon. Joust is a one-shot CLI.
+- Not generalizing the skill to other agents (Cursor etc.) — Claude
+  Code first, port if/when it matters.
+- Not building release artifacts in phase 0/1. Phase 2 is gated on
+  real demand.

--- a/spool/gh/issue/60-agent-installable/r2-gemini.md
+++ b/spool/gh/issue/60-agent-installable/r2-gemini.md
@@ -1,0 +1,52 @@
+Excellent. This revision is a significant improvement and demonstrates a clear understanding of the previous critiques. The shift to pre-built binaries, self-bootstrapping skills, and structured output addresses the core flaws of the original plan.
+
+However, my role is to find the new failure modes this plan introduces. Here are my critiques of v2.
+
+### 1. The `curl | sh` Install Pipe is a Loaded Gun
+The plan adopts the common `curl | sh` pattern for its convenience. While standard, it's a well-known security risk that is especially dangerous in an agent context where actions can be non-interactive. A temporary compromise of the GitHub repository (e.g., a compromised PAT allowing a malicious actor to edit a release asset) or a DNS hijacking attack could lead to arbitrary code execution on the user's machine, run by the agent without scrutiny.
+
+The plan lacks any mechanism to verify the integrity or authenticity of the downloaded binary.
+
+*   **Integrity:** The `install.sh` script should download the binary and a corresponding checksum file (e.g., `joust-linux-x64.sha256`). It must then run `sha256sum -c` to verify the binary's hash before making it executable. This protects against corrupted downloads and simple, opportunistic modifications.
+*   **Authenticity:** For a higher level of trust, the release artifacts should be signed (e.g., with GPG or, more modernly, Sigstore/`cosign`). The install script would need to verify this signature, which adds complexity (managing public keys) but provides much stronger guarantees against a sophisticated supply chain attack.
+
+For a tool intended to be invoked by an automated agent, shipping without at least checksum verification is a security oversight.
+
+### 2. The Binary-Skill Contract is Unversioned and Brittle
+The plan introduces a `--json` flag, creating a formal API contract between the `joust` binary and the Claude skill. This is a huge step up from parsing stdout. However, the plan is silent on how this contract will be versioned.
+
+This creates two immediate failure scenarios:
+1.  **New Skill, Old Binary:** The skill is updated to expect a new field in the JSON output (e.g., `status.currentFile`). A user who has an older `joust` binary that doesn't produce this field will cause the skill to fail with a JSON parsing or key access error.
+2.  **Old Skill, New Binary:** The binary is updated and removes or renames a field in the JSON output that the old skill depends on. The skill breaks.
+
+The idempotency check (`joust --version`) only handles upgrading to "latest," it doesn't manage compatibility. The skill itself needs to be aware of the binary version it supports.
+
+*   **Recommendation:** The skill's bootstrap logic must be smarter. It should:
+    1.  Define a required `joust` semantic version range (e.g., `^0.2.0`).
+    2.  If `joust` is found, run `joust --version`.
+    3.  If the version is outside the compatible range, force a re-install/upgrade.
+    4.  If the install fails or the resulting version is still incompatible, the skill must exit with a clear error message explaining the version mismatch.
+
+This makes the dependency explicit and prevents runtime failures due to API drift.
+
+### 3. The Cross-Compilation Plan for macOS is Wishful Thinking
+The plan correctly identifies the `darwin-arm64` build as a concern but hand-waves the solution: "May need `runs-on: macos-latest`". This is not a "may," it is a "must."
+
+While `bun --compile` has impressive cross-compilation capabilities for pure JS/TS code, the moment any native dependency is involved (which can happen transitively and unexpectedly), cross-compiling for macOS from a Linux runner becomes fragile to impossible. Apple's toolchains (Xcode, SDKs, linkers) are required to produce a correctly signed and functional binary. Relying on a Linux-based cross-compiler is a recipe for subtle runtime bugs, missing symbols, or complete build failure.
+
+The GitHub Actions workflow *must* include a build matrix that uses a `macos-latest` runner to build the `darwin-x64` and `darwin-arm64` targets natively. This is not a speculative optimization; it is a baseline requirement for producing reliable macOS binaries.
+
+### 4. The Install Script Assumes a Pristine, Standard Environment
+The plan for the install script is good, but it makes assumptions that will fail in common non-interactive or constrained environments where agents often run.
+
+*   **Missing Destination Directory:** The script plans to download to `~/.local/bin/joust`. What if `~/.local/bin` does not exist? The `curl` or `mv` operation will fail. The script must use `mkdir -p ~/.local/bin` before attempting to place the binary there.
+*   **Transient Failures:** What happens if `curl` fails due to a transient network error or a brief GitHub outage? The pipe to `sh` might receive an empty or partial script, leading to unpredictable errors. The install script itself, and the skill's logic for invoking it, must be resilient to this. The `curl` command should use flags like `--fail` to ensure it exits with an error code on HTTP failures, which the skill can then catch.
+*   **Permissions:** What if `~/.local/` is not writable by the current user? The script will fail. While less common, it's an edge case the script should detect and report clearly instead of dying on a cryptic `Permission denied` error.
+
+The script needs to be hardened with `set -e` (exit on error), directory creation, and more robust error checking to be truly "idiot-proof," especially when the "idiot" is an automaton with no intuition for debugging.
+
+***
+
+### Recommendation: Ship with Revisions
+
+The revised plan is on the right track, and the core concept is sound. Do not revert. However, shipping as-is would introduce significant security, compatibility, and reliability issues. The critiques above are not philosophical; they are practical failure modes that will manifest quickly. The plan should be amended to include checksum verification, an explicit versioning contract between the skill and the binary, a realistic build matrix using native macOS runners, and a more robust install script. These changes are essential for a trustworthy and reliable agent-first experience.

--- a/spool/gh/issue/60-agent-installable/r2.md
+++ b/spool/gh/issue/60-agent-installable/r2.md
@@ -1,0 +1,146 @@
+# Plan v2: install must be idiot-proof binary download
+
+Round 1 reviewed by Gemini. The core critique: build-from-source as
+the default install is malpractice for an agent. User concurred —
+install must be a binary, no bun, no build. Replanning around that.
+
+## What changed from r1
+
+- **Phase 2 (release artifacts) is now Phase 0.** Build-from-source is
+  not a v0 path; it's a recovery option only.
+- **The install script downloads a prebuilt binary.** No bun on the
+  user's machine. No compilation. No dependency on TypeScript runtime.
+- **PATH problem is solved at install time, not warned about.** The
+  install script either (a) places the binary somewhere already on PATH
+  or (b) prints absolute path so the agent can invoke directly.
+- **Skill commands handle their own install.** `/joust draft` checks
+  for joust, installs if missing, then runs the draft. No two-step
+  ritual where the agent has to remember to run install first.
+- **Skill output parsing minimized.** Where joust output drives agent
+  behavior, the binary should emit machine-readable form (JSON or
+  similar) the skill consumes — not stdout text the markdown parses.
+
+## Revised plan
+
+### Phase 0 — release infrastructure (must ship first)
+
+1. **GitHub Actions workflow** in joust on `git tag v*`:
+   - Build for `linux-x64`, `darwin-arm64`, `darwin-x64`.
+   - Upload binaries to a GitHub Release.
+   - Generate `install.sh` that detects platform/arch and downloads
+     the right binary. Hosted at the release.
+2. **`dev/release` script** — tags + pushes, optionally drafts release
+   notes from `git log`.
+3. **First release: `v0.2.0`** (after phase 2 of #42 shipped, which
+   it has).
+
+Output: `curl -fsSL https://github.com/ahoward/joust/releases/latest/download/install.sh | sh`
+installs joust on any supported platform. No bun required.
+
+### Phase 1 — install script semantics
+
+The install script (the one published with each release):
+
+1. Detects platform/arch. Errors clearly if unsupported.
+2. Downloads the matching binary to `~/.local/bin/joust`.
+3. `chmod +x`.
+4. **PATH handling, not warning:**
+   - If `~/.local/bin` is on `PATH`: silent success.
+   - If not on `PATH`: print the absolute path on the last line of
+     stdout, in a parseable format (`JOUST_BINARY=/home/.../joust`).
+     The skill captures it.
+5. Verifies install by running `joust --version` (a flag joust must
+   add — it doesn't currently have it).
+6. Idempotent. Re-running upgrades to latest.
+
+### Phase 2 — Claude Code skill at `.claude/skills/joust/`
+
+Skill structure:
+
+```
+.claude/skills/joust/
+  SKILL.md             # what joust is, when to use it, install bootstrap
+  commands/
+    draft.md           # check-or-install, then `joust draft <prompt>`
+    pickup.md          # resume from .joust/<slug>/
+    review.md          # parse machine-readable status, summarize
+    status.md          # call joust /status, render
+```
+
+Critical changes from r1:
+
+- **No standalone `install.md` command.** Each command that needs
+  joust runs the install bootstrap itself if needed. `/joust draft`
+  alone is sufficient — first invocation might install, subsequent
+  invocations skip the check.
+- **Install bootstrap pattern (in every command):**
+  ```
+  1. Check `which joust` or `command -v joust`.
+  2. If missing: curl the install.sh from latest release, exec.
+  3. Capture absolute path from install output.
+  4. Run the command.
+  ```
+- **Output consumption is structured.** The skill calls `joust /status
+  --json` (a flag joust must add) and parses JSON, not stdout text.
+  No markdown parsing of human-formatted output.
+
+### Phase 3 — minor binary changes joust needs
+
+The skill needs three things from the binary that don't exist yet:
+
+1. **`joust --version`** — flag that prints semver. Used by install
+   verification and skill bootstrap.
+2. **`joust /status --json`** — emit machine-readable status. Skill
+   reads structured fields, doesn't grep stdout.
+3. **`joust --help` exit code 0.** Already correct.
+
+These are small additions to `src/cli.ts`. Ship as part of the v0.2.0
+release.
+
+## What I'm cutting from r1
+
+- "Build-from-source is v0." Wrong, removed.
+- "`dev/install` is independently useful for humans." It is, but the
+  binary downloader is also independently useful and dramatically
+  simpler.
+- "Phase 2 deferred until users." Wrong. The install path *is* the
+  user-facing surface. Has to ship.
+
+## What I'm keeping from r1
+
+- Skill lives in the joust repo (`.claude/skills/joust/`) for now.
+  Generalize to other agents later.
+- Skill is a thin wrapper over the binary, not a reimplementation.
+- Install location: `~/.local/bin/joust`. No sudo.
+
+## Concerns with the revised plan
+
+- **GitHub Actions workflow has to actually work for darwin-arm64.**
+  Bun's `--compile` cross-compilation works but I haven't verified it
+  on an Actions runner. May need `runs-on: macos-latest` for Apple
+  Silicon target.
+- **Idempotency.** If joust is already installed at a newer version
+  than the release binary's, install should warn and ask, not
+  silently downgrade.
+- **Network.** First-run requires network. Acceptable for a CLI tool;
+  document it.
+- **Binary size.** ~100MB compiled. GitHub Releases supports up to 2GB
+  per asset; fine. Download is the user's bandwidth concern.
+
+## Order of operations
+
+1. Add `--version` and `--json` flags to joust binary.
+2. Add GitHub Actions workflow that builds + releases on tag.
+3. Tag v0.2.0, verify Release artifacts populate.
+4. Write the install script and host it in the Release.
+5. Write the skill (~5 markdown files).
+6. End-to-end smoke: `git clone` into `/tmp/foo`, `cd /tmp/foo`, start
+   Claude Code, ask "design X with joust." Agent installs, runs,
+   reports. No human intervention.
+
+## Revised recommendation
+
+Ship in this order. Each step is small and verifiable. The total path
+is: working install script + tested binary + skill that uses both.
+The original r1 plan would have shipped a broken first-contact
+experience.

--- a/spool/gh/issue/60-agent-installable/r3.md
+++ b/spool/gh/issue/60-agent-installable/r3.md
@@ -1,0 +1,237 @@
+# Plan v3 (final): joust as agent-installable
+
+After r2 review with Gemini. Four real hits, all addressed.
+
+## What changed from r2
+
+1. **Checksum verification.** Install script verifies SHA256 against a
+   sidecar file before executing the binary. Without this, `curl | sh`
+   is one supply-chain compromise away from arbitrary code execution
+   on the agent's host.
+2. **Binary↔skill version contract.** Skill declares minimum required
+   joust version. On bootstrap, checks `joust --version`; if
+   incompatible, re-install. Drift between skill expectations and
+   binary capabilities becomes explicit and actionable.
+3. **macOS native runners.** GH Actions uses a build matrix with
+   `macos-latest` for darwin builds. No cross-compile from Linux.
+4. **Robust install script.** `set -euo pipefail`, `curl --fail`,
+   `mkdir -p`, explicit error messages on permission failure.
+
+## Final plan
+
+### Phase 0 — release infrastructure (must ship first)
+
+**GH Actions workflow** at `.github/workflows/release.yml`, triggered on `git tag v*`:
+
+```yaml
+strategy:
+  matrix:
+    include:
+      - os: ubuntu-latest
+        target: linux-x64
+      - os: macos-latest
+        target: darwin-arm64
+      - os: macos-13   # Intel macOS for x64 builds
+        target: darwin-x64
+steps:
+  - bun build --compile --target=$BUN_TARGET
+  - sha256sum joust-$TARGET > joust-$TARGET.sha256
+  - upload to GitHub Release (binary + sha256)
+```
+
+Per release, six artifacts: 3 binaries × (binary + checksum). Plus an
+`install.sh` script that's also a release asset (or hosted in the repo
+and pulled by tag).
+
+**No darwin cross-compile from Linux.** macOS targets built on macOS
+runners. Linux on Linux. (Windows deferred — joust is bun-only and
+Windows support is its own problem.)
+
+### Phase 1 — install script
+
+`install.sh` (hosted at the latest release):
+
+```sh
+#!/bin/sh
+set -eu
+
+# detect platform + arch
+OS=$(uname -s | tr A-Z a-z)
+ARCH=$(uname -m)
+case "$OS-$ARCH" in
+  linux-x86_64)  TARGET=linux-x64 ;;
+  darwin-arm64)  TARGET=darwin-arm64 ;;
+  darwin-x86_64) TARGET=darwin-x64 ;;
+  *) echo "joust: unsupported platform $OS-$ARCH" >&2; exit 1 ;;
+esac
+
+# resolve target version (defaults to latest)
+VERSION="${JOUST_VERSION:-latest}"
+if [ "$VERSION" = "latest" ]; then
+  RELEASE_BASE="https://github.com/ahoward/joust/releases/latest/download"
+else
+  RELEASE_BASE="https://github.com/ahoward/joust/releases/download/$VERSION"
+fi
+
+# install dir + binary
+INSTALL_DIR="${JOUST_INSTALL_DIR:-$HOME/.local/bin}"
+mkdir -p "$INSTALL_DIR"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# download binary + checksum, verify
+curl --fail --silent --show-error -L "$RELEASE_BASE/joust-$TARGET" -o "$TMPDIR/joust"
+curl --fail --silent --show-error -L "$RELEASE_BASE/joust-$TARGET.sha256" -o "$TMPDIR/joust.sha256"
+EXPECTED=$(awk '{print $1}' "$TMPDIR/joust.sha256")
+ACTUAL=$(sha256sum "$TMPDIR/joust" | awk '{print $1}')
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "joust: checksum mismatch" >&2
+  echo "  expected: $EXPECTED" >&2
+  echo "  actual:   $ACTUAL" >&2
+  exit 1
+fi
+
+# place + chmod, atomic move
+chmod +x "$TMPDIR/joust"
+mv "$TMPDIR/joust" "$INSTALL_DIR/joust"
+
+# verify by running --version
+if ! "$INSTALL_DIR/joust" --version >/dev/null 2>&1; then
+  echo "joust: installed binary failed --version probe at $INSTALL_DIR/joust" >&2
+  exit 1
+fi
+
+# tell the agent (and human) the result
+INSTALLED_VERSION=$("$INSTALL_DIR/joust" --version)
+echo "joust: installed $INSTALLED_VERSION at $INSTALL_DIR/joust"
+
+# PATH detection — output in agent-parseable form
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *) echo "JOUST_BINARY=$INSTALL_DIR/joust" ;;  # agent reads this var name
+esac
+```
+
+Key properties:
+- `set -eu`, `--fail`, `mkdir -p`, atomic mv via temp dir.
+- Checksum verified before chmod.
+- `JOUST_BINARY=...` last-line output is parseable by the skill so it
+  can invoke joust by absolute path even if `~/.local/bin` is not on
+  `$PATH`. The skill reads stdout for that pattern.
+- `JOUST_VERSION=v0.2.0 sh install.sh` pins a specific version (used
+  by skill version contract enforcement).
+- `JOUST_INSTALL_DIR=/usr/local/bin sh install.sh` allows overriding
+  the install location.
+
+### Phase 2 — binary changes
+
+Three small additions to `src/cli.ts`, must ship in v0.2.0:
+
+1. **`joust --version`** prints semver from `package.json`.
+2. **`joust /status --json`** emits machine-readable status:
+   ```json
+   {
+     "step": 5,
+     "best_aggregate": 0.883,
+     "best_color_tier": "green",
+     "strategies": ["invariants", "rubric"],
+     "declined": [{"name": "color", "rationale": "..."}],
+     "aggregate_history": [0.62, 0.78, 0.84],
+     "pending_summon": null
+   }
+   ```
+3. **`joust /export --json`** emits the best draft + the structured
+   ScoringResult so the skill can render scores in conversation
+   without re-running status.
+
+The JSON shape becomes part of the v0.2.0+ contract. Breaking changes
+require a major version bump (per the skill's compat range).
+
+### Phase 3 — Claude Code skill at `.claude/skills/joust/`
+
+Structure:
+
+```
+.claude/skills/joust/
+  SKILL.md             # what joust is, when to use it
+  commands/
+    draft.md           # bootstrap + run wrapper
+    pickup.md          # resume from .joust/<slug>/
+    review.md          # parse --json status/export, summarize
+    status.md          # call /status --json, render
+```
+
+Every command begins with the **install bootstrap pattern**:
+
+```sh
+# 1. find joust (PATH or env hint from previous install)
+JOUST=${JOUST_BINARY:-$(command -v joust 2>/dev/null || true)}
+
+# 2. version check
+if [ -n "$JOUST" ]; then
+  CURRENT=$("$JOUST" --version 2>/dev/null | sed 's/^v//')
+  if ! semver_in_range "$CURRENT" ">=0.2.0 <1.0.0"; then
+    JOUST=""  # force reinstall
+  fi
+fi
+
+# 3. install if needed
+if [ -z "$JOUST" ]; then
+  INSTALL_OUTPUT=$(curl -fsSL https://github.com/ahoward/joust/releases/latest/download/install.sh | sh)
+  JOUST=$(echo "$INSTALL_OUTPUT" | grep -oE 'JOUST_BINARY=.*' | cut -d= -f2)
+  JOUST=${JOUST:-$(command -v joust)}
+fi
+
+# 4. proceed with the actual command
+"$JOUST" /draft "$prompt"
+```
+
+Skill declares its required version range in `SKILL.md`:
+> Requires joust >=0.2.0 <1.0.0. Bootstrap installs the latest matching
+> version automatically.
+
+### Phase 4 — versioning policy (tracked separately)
+
+Going forward:
+- v0.x = pre-stable; minor bumps may break `--json` shape.
+- v1.0+ = stable; `--json` is part of the public API.
+- Skill's compat range matches the joust major version.
+- Skill's `SKILL.md` documents the version range; bump when the binary
+  changes break the contract.
+
+## Order of operations
+
+1. `joust --version` flag + `--json` flag for `/status` + `/export`.
+   Smallest binary changes.
+2. GH Actions workflow (`release.yml`) with the build matrix.
+3. Manually tag `v0.2.0`. Verify all six artifacts populate.
+4. Write `install.sh`. Smoke test it: clean machine, run `curl | sh`,
+   verify joust runs.
+5. Write the skill. Smoke test: clean machine + `git clone`, start
+   Claude Code session, ask "design X with joust." Skill installs,
+   runs, reports without intervention.
+
+## Concerns surviving round 3
+
+- **Sigstore/cosign signing was deferred.** Sha256 verification covers
+  most real attacks. Signing is the fully-paranoid version; deferring
+  until joust has users worth attacking.
+- **Binary size.** ~100MB per platform × 3 platforms = ~300MB per
+  release. GitHub doesn't charge for release assets but it's a lot of
+  download traffic.
+- **macOS code signing / notarization.** Apple Gatekeeper will warn
+  on first run for an unsigned binary. The user has to right-click →
+  Open the first time, or `xattr -d com.apple.quarantine`. Document.
+  Real fix is notarization; deferred.
+- **`bun --compile` produces large binaries because Bun bundles the
+  whole runtime.** Could investigate `--minify` and dead-code
+  elimination, but 100MB is acceptable for v0.2.0.
+- **The install pipe `curl | sh` runs arbitrary script content.** The
+  script itself is the trust boundary. Future: ship via a signed package
+  manager (brew tap, etc.). Out of scope for v0.2.0.
+
+## Recommendation
+
+Ship in this order. Each phase is independently testable. The shape is
+right and the new failure modes Gemini caught (checksum, version
+contract, native macOS, robust install) are addressed. Ready to execute.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,11 +15,12 @@ normalize_gemini_env();
 // --- known commands (slash-prefixed) ---
 
 const COMMANDS = new Set([
-  "init", "prompt", "run", "tail", "status", "export", "diff", "plan", "ask", "help",
+  "init", "prompt", "run", "tail", "status", "export", "diff", "plan", "ask", "help", "version",
 ]);
 
 function parse_command(raw: string): { command: string; is_command: boolean } {
   if (raw === "--help" || raw === "-h") return { command: "help", is_command: true };
+  if (raw === "--version" || raw === "-v") return { command: "version", is_command: true };
   if (raw.startsWith("/")) {
     const name = raw.slice(1);
     if (COMMANDS.has(name)) return { command: name, is_command: true };
@@ -30,17 +31,20 @@ function parse_command(raw: string): { command: string; is_command: boolean } {
 
 // --- arg parsing ---
 
-function parse_args(argv: string[]): { command: string; is_command: boolean; rest: string[]; options: RunOptions; preset?: Preset } {
+function parse_args(argv: string[]): { command: string; is_command: boolean; rest: string[]; options: RunOptions; preset?: Preset; json: boolean } {
   const first = argv[0] ?? "--help";
   const { command, is_command } = parse_command(first);
   const rest: string[] = [];
   const options: RunOptions = {};
   let preset: Preset | undefined;
+  let json = false;
 
   for (let i = 1; i < argv.length; i++) {
     const arg = argv[i];
 
-    if (arg === "--tank") {
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--tank") {
       options.tank = true;
     } else if (arg.startsWith("--timebox")) {
       if (arg.includes("=")) {
@@ -76,11 +80,11 @@ function parse_args(argv: string[]): { command: string; is_command: boolean; res
     }
   }
 
-  return { command, is_command, rest, options, preset };
+  return { command, is_command, rest, options, preset, json };
 }
 
 async function main() {
-  const { command, is_command, rest, options, preset } = parse_args(process.argv.slice(2));
+  const { command, is_command, rest, options, preset, json } = parse_args(process.argv.slice(2));
 
   // bare string — treat entire argv as a prompt and draft it
   // e.g. `joust "design a caching layer"` => `joust /draft "design a caching layer"`
@@ -116,12 +120,12 @@ async function main() {
     }
 
     case "status": {
-      status(rest[0] || ".");
+      status(rest[0] || ".", { json });
       break;
     }
 
     case "export": {
-      export_draft(rest[0] || ".");
+      export_draft(rest[0] || ".", { json });
       break;
     }
 
@@ -150,7 +154,20 @@ async function main() {
       print_help();
       break;
     }
+
+    case "version": {
+      print_version();
+      break;
+    }
   }
+}
+
+// version is read from package.json via bun's import-as-json. compiled
+// binaries embed package.json so this works post-bundle.
+import pkg from "../package.json" with { type: "json" };
+function print_version() {
+  // print to stdout (not stderr like log()) so install scripts can capture
+  process.stdout.write(`v${pkg.version}\n`);
 }
 
 function print_help() {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,13 +11,49 @@ import type { HistoryEntry } from "./types";
 
 // --- joust status ---
 
-export function status(dir: string): void {
+export function status(dir: string, opts: { json?: boolean } = {}): void {
   dir = resolve(dir);
   const files = scan_history(dir);
   const latest = read_latest_history(dir);
 
   if (!latest) {
-    log("no history found — run 'joust init' first");
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ error: "no history found", dir }) + "\n");
+    } else {
+      log("no history found — run 'joust init' first");
+    }
+    return;
+  }
+
+  // --- machine-readable form (#60) ---
+  if (opts.json) {
+    const snow: any = latest.snowball;
+    const accepted = files.filter((f) => {
+      try {
+        const e = JSON.parse(readFileSync(f.path, "utf-8"));
+        return e.status === "accepted";
+      } catch { return false; }
+    }).length;
+    const out = {
+      schema_version: 1,
+      step: latest.step,
+      actor: latest.actor,
+      action: latest.action,
+      status: latest.status,
+      history_count: files.length,
+      accepted_count: accepted,
+      rejected_count: files.length - accepted,
+      strategies: snow.strategies ?? null,
+      declined_strategies: snow.declined_strategies ?? [],
+      best_aggregate: snow.best_scoring?.weighted_aggregate ?? null,
+      best_color_tier: snow.best_scoring?.color_tier ?? null,
+      best_scorecards: snow.best_scoring?.scorecards ?? [],
+      aggregate_history: snow.aggregate_history ?? [],
+      pending_summon: snow.pending_summon ?? null,
+      draft_chars: (snow.best_draft ?? snow.draft).length,
+      critique_count: snow.critique_trail?.length ?? 0,
+    };
+    process.stdout.write(JSON.stringify(out, null, 2) + "\n");
     return;
   }
 
@@ -82,18 +118,40 @@ export function status(dir: string): void {
 
 // --- joust export ---
 
-export function export_draft(dir: string): void {
+export function export_draft(dir: string, opts: { json?: boolean } = {}): void {
   dir = resolve(dir);
   set_log_dir(dir);
   const latest = read_latest_history(dir);
 
   if (!latest) {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify({ error: "no history found", dir }) + "\n");
+      return;
+    }
     throw new JoustUserError("no history found — run 'joust /init' first");
   }
 
   // phase 1 of #42: emit best_draft when strategy scoring tracked it;
   // fall back to current draft for legacy runs that never scored.
   const out = latest.snowball.best_draft ?? latest.snowball.draft;
+
+  // machine-readable form (#60). bundles the draft + structured scoring
+  // so a skill can render scores in conversation without re-running
+  // /status. schema_version pins the contract.
+  if (opts.json) {
+    const snow: any = latest.snowball;
+    const payload = {
+      schema_version: 1,
+      draft: out,
+      best_aggregate: snow.best_scoring?.weighted_aggregate ?? null,
+      best_color_tier: snow.best_scoring?.color_tier ?? null,
+      scorecards: snow.best_scoring?.scorecards ?? [],
+      strategies: snow.strategies ?? null,
+    };
+    process.stdout.write(JSON.stringify(payload, null, 2) + "\n");
+    return;
+  }
+
   write_stdout(out);
 }
 


### PR DESCRIPTION
Implements #60. After three rounds of adversarial review with Gemini (preserved in `spool/gh/issue/60-agent-installable/r{1,2,3}*.md`).

The plan reversal that mattered most: Gemini and the user both vetoed build-from-source as the default install path. Result: install must be a binary download, no bun, no compilation, with sha256 verification.

## What ships

**Binary (small additions to src/cli.ts + src/commands.ts)**
- `joust --version` — prints `v0.2.0` to stdout. Goes through dispatch, also responds to `-v` and `/version`.
- `joust /status [dir] --json` — machine-readable status (schema_version: 1) including strategies, declined_strategies, best aggregate, scorecards, aggregate_history, pending_summon.
- `joust /export [dir] --json` — machine-readable best draft + scorecards.

**Release infrastructure (.github/workflows/release.yml)**
- Build matrix: `ubuntu-latest`, `macos-latest` (arm64), `macos-13` (x64). Native runners — no cross-compile.
- On `v*` tag: builds all three, computes sha256 sidecars, publishes a GitHub Release with binaries + checksums + install.sh.

**install.sh (POSIX sh)**
- `set -eu`, `curl --fail`, `mkdir -p`, atomic mv via temp dir.
- Downloads binary + sha256 from the release. Verifies BEFORE chmod.
- Handles both `sha256sum` and `shasum -a 256`.
- Defaults to `~/.local/bin/joust`, override via `JOUST_INSTALL_DIR`. Pin version via `JOUST_VERSION`.
- Emits `JOUST_BINARY=<path>` as last stdout line if install dir isn't on $PATH, so agents can capture it.

**Claude Code skill (.claude/skills/joust/)**
- SKILL.md + commands/{draft,pickup,review,status}.md.
- Every subcommand opens with install bootstrap (check version, install if missing or out of compat range).
- Reads `--json` output, never parses stdout text. Never edits .joust/<slug>/ directly.

## After merge

Tag `v0.2.0` to trigger the release workflow. First successful release proves the full agent-install flow.

156 tests pass. Binary compiles. install.sh syntax-checked.

Refs: #60.