### PR TITLE
fix(release): drop darwin-x64 from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,11 @@ jobs:
           - os: macos-latest
             target: darwin-arm64
             asset: joust-darwin-arm64
-          - os: macos-13
-            target: darwin-x64
-            asset: joust-darwin-x64
+          # darwin-x64 (Intel macOS) is intentionally not in the build matrix.
+          # GH Actions' macos-13 runner pool was severely queue-starved on
+          # 2026-05-03; first attempt sat 50+ min waiting. Apple Silicon is
+          # mandatory; Intel macOS users can install from source or use Rosetta
+          # against the darwin-arm64 binary.
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/install.sh
+++ b/install.sh
@@ -26,10 +26,15 @@ ARCH="$(uname -m)"
 case "$OS-$ARCH" in
   linux-x86_64)  TARGET="linux-x64" ;;
   darwin-arm64)  TARGET="darwin-arm64" ;;
-  darwin-x86_64) TARGET="darwin-x64" ;;
+  darwin-x86_64)
+    echo "joust: Intel macOS (darwin-x64) is not currently published as a release binary." >&2
+    echo "joust: install from source: git clone https://github.com/$REPO && cd joust && bun build ./src/cli.ts --compile --outfile ~/.local/bin/joust" >&2
+    echo "joust: or run the darwin-arm64 binary under Rosetta if available." >&2
+    exit 1
+    ;;
   *)
     echo "joust: unsupported platform $OS-$ARCH" >&2
-    echo "joust: supported: linux-x64, darwin-arm64, darwin-x64" >&2
+    echo "joust: supported: linux-x64, darwin-arm64" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
First v0.2.0 tag attempt got stuck — darwin-x64 (macos-13) build sat queued for 50+ minutes on GH Actions' Intel runner pool with no sign of starting. The other two builds finished in seconds.

Apple Silicon is mandatory for the published binary. Intel macOS users build from source or run darwin-arm64 under Rosetta. install.sh now produces a clear error + remediation when an Intel macOS host hits it.

After this merges, retag v0.2.0 to trigger the slimmer release.

Refs: #60.